### PR TITLE
fix: make partial indexing and Ellipsis work in Hist.__getitem__

### DIFF
--- a/src/cuda_histogram/hist.py
+++ b/src/cuda_histogram/hist.py
@@ -144,20 +144,24 @@ class Hist:
             for s in [keys.start, keys.stop, keys.step]
         ):
             raise ValueError("use to_boost/to_hist to access other UHI functionalities")
-        if not isinstance(keys, slice) and not isinstance(keys, int | float | tuple):
+        if (
+            not isinstance(keys, slice)
+            and keys is not Ellipsis
+            and not isinstance(keys, int | float | tuple)
+        ):
             raise ValueError("use to_boost/to_hist to access other UHI functionalities")
         if not isinstance(keys, tuple):
             keys = (keys,)
-        if len(keys) != self.dim():
-            raise IndexError("Too many or too less indices for this histogram")
+        if keys.count(Ellipsis) > 1:
+            raise IndexError("an index can only have a single ellipsis ('...')")
+        if Ellipsis in keys:
+            idx = keys.index(Ellipsis)
+            slices = (slice(None),) * (self.dim() - len(keys) + 1)
+            keys = keys[:idx] + slices + keys[idx + 1 :]
         elif len(keys) < self.dim():
-            if Ellipsis in keys:
-                idx = keys.index(Ellipsis)
-                slices = (slice(None),) * (self.dim() - len(keys) + 1)
-                keys = keys[:idx] + slices + keys[idx + 1 :]
-            else:
-                slices = (slice(None),) * (self.dim() - len(keys))
-                keys += slices
+            keys += (slice(None),) * (self.dim() - len(keys))
+        if len(keys) > self.dim():
+            raise IndexError("too many indices for this histogram")
         sparse_idx = []
         dense_idx = []
         new_dims = []

--- a/tests/test_hist_tools.py
+++ b/tests/test_hist_tools.py
@@ -111,6 +111,29 @@ def test_hist():
     assert (h[:, 0].variance() == h.variance()[:, 0].reshape((20, 1))).all()
 
 
+def test_partial_indexing():
+    counts, test_eta, test_pt = dummy_jagged_eta_pt()
+
+    h = cuda_histogram.Hist(
+        cuda_histogram.axis.Regular(20, 0, 2, label="x", name="x"),
+        cuda_histogram.axis.Variable([0, 5, 15, 30], label="y", name="why"),
+    )
+    h.fill(test_eta, test_pt)
+
+    assert (h[0.1].values() == h[0.1, :].values()).all()
+    assert (h[...].values() == h.values()).all()
+    assert h[...].axes() == h.axes()
+    assert (h[0.1, ...].values() == h[0.1, :].values()).all()
+    assert (h[..., 3].values() == h[:, 3].values()).all()
+
+    with pytest.raises(IndexError):
+        h[0.1, 3, 5]
+    with pytest.raises(IndexError):
+        h[..., ...]
+    with pytest.raises(ValueError):
+        h["x"]
+
+
 def test_cpu_conversion():
     import boost_histogram as bh
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`Hist.__getitem__` guarded with `if len(keys) != self.dim(): raise IndexError`, followed by an `elif len(keys) < self.dim():` branch — so the Ellipsis expansion and `slice(None)` right-padding it contained were unreachable dead code. A bare `...` was additionally rejected up front, since the type check only accepted slice/int/float/tuple.

Now the validation accepts `Ellipsis` (bare and inside tuples), the expansion/padding runs first, and `IndexError` is raised only when there are genuinely too many indices (message grammar fixed too). More than one `...` raises `IndexError`, matching numpy. So on a 2-D histogram `h[0.1]`, `h[...]`, `h[0.1, ...]` and `h[..., 3]` all work. Indexing stays deliberately narrow otherwise: indices are values in bin-edge coordinates, and anything fancier still raises the "use to_boost/to_hist" `ValueError`.

Regression tests added in `tests/test_hist_tools.py`. The full suite was run locally on an H100 (CI has no GPU and skips these tests); everything passes except the pre-existing `test_cpu_conversion` `to_boost` failure being fixed separately.

Part of #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)
