### PR TITLE
fix: support boost-histogram >=1.7 and hist >=2.10 in to_boost

### DIFF
--- a/src/cuda_histogram/hist.py
+++ b/src/cuda_histogram/hist.py
@@ -351,29 +351,33 @@ class Hist:
         All the arguments of cuda-histogram's axis and histogram are passed down.
         """
         import boost_histogram
+        import hist
 
+        # hist's axes subclass boost-histogram's and carry name/label properly
         newaxes = []
         for axis in self.axes():
             if isinstance(axis, Regular):
-                newaxis = boost_histogram.axis.Regular(
-                    axis._bins,
-                    axis._lo,
-                    axis._hi,
-                    underflow=True,
-                    overflow=True,
+                newaxes.append(
+                    hist.axis.Regular(
+                        axis._bins,
+                        axis._lo,
+                        axis._hi,
+                        underflow=True,
+                        overflow=True,
+                        name=axis.name,
+                        label=axis.label,
+                    )
                 )
-                newaxis._ax.metadata["name"] = axis.name
-                newaxis.label = axis.label
-                newaxes.append(newaxis)
             elif isinstance(axis, Variable):
-                newaxis = boost_histogram.axis.Variable(
-                    axis.edges(),
-                    underflow=True,
-                    overflow=True,
+                newaxes.append(
+                    hist.axis.Variable(
+                        axis.edges().get(),
+                        underflow=True,
+                        overflow=True,
+                        name=axis.name,
+                        label=axis.label,
+                    )
                 )
-                newaxis._ax.metadata["name"] = axis.name
-                newaxis.label = axis.label
-                newaxes.append(newaxis)
             # TODO: cleanup logic for sparse axis
             # elif isinstance(axis, Cat):
             #     identifiers = self.identifiers(axis)

--- a/tests/test_hist_tools.py
+++ b/tests/test_hist_tools.py
@@ -156,3 +156,24 @@ def test_cpu_conversion():
     assert h.values().shape == dummy.values().shape
     assert h[bh.underflow, bh.underflow].variance == 4.0
     assert h.storage_type == bh.storage.Weight
+
+
+def test_hist_conversion():
+    import hist as hist_mod
+
+    dummy = cuda_histogram.Hist(
+        cuda_histogram.axis.Regular(1, 0, 1, name="dummy", label="Number of events"),
+        cuda_histogram.axis.Variable([0, 2, 3, 10], name="var", label="Variable axis"),
+        name="Dummy",
+        label="Just Dummy",
+    )
+    dummy.fill(cp.array(0.05), cp.array(0.05))
+
+    h = dummy.to_hist()
+    assert isinstance(h, hist_mod.Hist)
+    assert h.axes[0].name == "dummy"
+    assert h.axes[0].label == "Number of events"
+    assert h.axes[1].name == "var"
+    assert h.axes[1].label == "Variable axis"
+    assert h[0, 0] == 1.0
+    assert h.values().shape == dummy.values().shape


### PR DESCRIPTION
:robot: _AI text below_ :robot:

`Hist.to_boost()` set axis names by writing into `newaxis._ax.metadata`, an internal of the raw boost-histogram axis that no longer exists (`AttributeError: 'boost_histogram._core.axis.regular_uoflow' object has no attribute 'metadata'` with boost-histogram 1.7). Separately, hist >= 2.10 reads axis names from `_raw_metadata`, so even where the old poke worked the name would no longer survive into `to_hist()`.

Fix: build `hist.axis.Regular` / `hist.axis.Variable` with `name=` and `label=` instead. Those subclass the boost-histogram axes, so `isinstance(ax, bh.axis.Regular)` still holds, they work inside `bh.Histogram`, and the names now propagate through `to_hist()`. `hist` is already a hard dependency. Variable edges are now moved to the host explicitly rather than handing CuPy arrays to boost-histogram.

CI never caught this: it runs GPU-less, so `tests/test_hist_tools.py` skips entirely there. The existing `test_cpu_conversion` is the regression test (fails before, passes after), and a small `test_hist_conversion` was added since `to_hist()` had no coverage at all.

Full suite run locally on an H100 (boost-histogram 1.7.2, hist 2.10.1): 4 passed.

Part of #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)
