### PR TITLE
fix: clamp underflow indices and correct nanflow bin placement

### DIFF
--- a/src/cuda_histogram/axis/__init__.py
+++ b/src/cuda_histogram/axis/__init__.py
@@ -25,8 +25,7 @@ _clip_bins = cupy.ElementwiseKernel(
     "T idx",
     """
     const T floored = floor((id - lo) * float(Nbins) / (hi - lo)) + 1;
-    idx = floored < 0 ? 0 : floored;
-    idx = floored > Nbins ? Nbins + 1 : floored;
+    idx = floored < 0 ? 0 : (floored > Nbins ? Nbins + 1 : floored);
     """,
     "clip_bins",
 )
@@ -411,7 +410,7 @@ class Bin(DenseAxis):
         if isinstance(n_or_arr, list | np.ndarray | cupy.ndarray):
             self._uniform = False
             self._bins = cupy.array(n_or_arr, dtype="d")
-            if not all(np.sort(self._bins) == self._bins):
+            if not bool((self._bins[:-1] < self._bins[1:]).all()):
                 raise ValueError("Binning not sorted!")
             self._lo = self._bins[0]
             self._hi = self._bins[-1]
@@ -431,8 +430,17 @@ class Bin(DenseAxis):
                 cupy.nan,
             ]
             self._bin_names = np.full(self._interval_bins[:-1].size, None)
+        else:
+            raise TypeError(
+                f"Expected an integer number of bins or an array of bin edges, got {n_or_arr!r}"
+            )
         self._label = label
         self._name = name
+
+    @property
+    def _nanflow_index(self):
+        """Dense index of the nanflow bin (``n+2``)"""
+        return self._bins + 2 if self._uniform else len(self._bins)
 
     def __repr__(self):
         class_name = self.__class__.__name__
@@ -505,12 +513,12 @@ class Bin(DenseAxis):
 
                 if isinstance(idx, cupy.ndarray | np.ndarray):
                     _replace_nans(
-                        self.size - 1,
+                        self._nanflow_index,
                         idx if idx.dtype.kind == "f" else idx.astype(cupy.float32),
                     )
                     idx = idx.astype(int)
                 elif np.isnan(idx):
-                    idx = self.size - 1
+                    idx = self._nanflow_index
                 else:
                     idx = int(idx)
                 return idx
@@ -518,7 +526,7 @@ class Bin(DenseAxis):
                 return cupy.searchsorted(self._bins, identifier, side="right")
         elif isinstance(identifier, Interval):
             if identifier.nan():
-                return self.size - 1
+                return self._nanflow_index
             for idx, interval in enumerate(self._intervals):
                 if (
                     interval._lo <= identifier._lo

--- a/tests/test_hist_tools.py
+++ b/tests/test_hist_tools.py
@@ -134,6 +134,46 @@ def test_partial_indexing():
         h["x"]
 
 
+def test_underflow_index_and_fill():
+    ax = cuda_histogram.axis.Regular(10, 0, 1)
+    assert int(ax.index(cp.array([-5.0]))[0]) == 0
+    assert int(ax.index(cp.array([5.0]))[0]) == 11
+
+    h = cuda_histogram.Hist(cuda_histogram.axis.Regular(10, 0, 1, name="x"))
+    h.fill(cp.array([-5.0]))
+    values = h.values(flow=True)
+    assert int(values[0]) == 1
+    assert int(values.sum()) == 1
+
+
+def test_nanflow_index_and_fill():
+    ax = cuda_histogram.axis.Regular(10, 0, 1)
+    assert int(ax.index(cp.array([np.nan]))[0]) == 12
+    assert int(cp.asarray(ax.index(float("nan"))).reshape(-1)[0]) == 12
+    assert ax.index(cuda_histogram.axis.Interval(3.0, np.nan)) == 12
+
+    axv = cuda_histogram.axis.Variable([0, 1, 2, 3])
+    assert int(axv.index(cp.array([np.nan]))[0]) == 5
+    assert axv.index(cuda_histogram.axis.Interval(3.0, np.nan)) == 5
+
+    h = cuda_histogram.Hist(cuda_histogram.axis.Regular(10, 0, 1, name="x"))
+    h.fill(cp.array([np.nan]))
+    values = h.values(flow=True)
+    assert int(values[-1]) == 1
+    assert int(values.sum()) == 1
+
+
+def test_bin_validation():
+    with pytest.raises(TypeError):
+        cuda_histogram.axis.Bin(3.5, 0, 1)
+    with pytest.raises(TypeError):
+        cuda_histogram.axis.Regular(3.5, 0, 1)
+    with pytest.raises(ValueError, match="not sorted"):
+        cuda_histogram.axis.Variable([0, 2, 1])
+    with pytest.raises(ValueError, match="not sorted"):
+        cuda_histogram.axis.Variable([0, 1, 1, 2])
+
+
 def test_cpu_conversion():
     import boost_histogram as bh
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Three correctness bugs in `cuda_histogram.axis`, all verified on a GPU:

- **Underflow clamp was dead code.** In the `_clip_bins` kernel the second ternary
  unconditionally overwrote the first, so `floored < 0` never clamped to 0.
  `Regular(10, 0, 1).index(-5.0)` returned `-49`, and `Hist.fill` then wrapped that
  negative index through `cupy.ravel_multi_index` into visible bin 3 — silent
  corruption of in-range bins rather than an underflow count.
- **Nanflow index off by three.** `Bin.index` used `self.size - 1` for the nanflow
  bin, which was correct in coffea where `size` counted the flow bins but is wrong
  here. NaN values landed in the last *visible* bin for `Regular` (index 9 instead
  of 12 for `Regular(10, 0, 1)`) and in the overflow bin for `Variable` interval
  lookups — again silently polluting real data. Replaced with a `_nanflow_index`
  helper used by all three call sites; the `Variable` array path (searchsorted past
  `inf`) was already correct and is unchanged.
- **Missing `Bin` validation.** `Bin(3.5, 0, 1)` matched neither constructor branch,
  leaving `_bins`/`_uniform` unset and surfacing as a confusing `AttributeError`
  much later; it now raises `TypeError`. The edge-sortedness check also iterated the
  CuPy array from Python (one device sync per edge) and accepted duplicate edges,
  which silently create zero-width bins. It is now a vectorized strictly-ascending
  check, matching `boost_histogram.axis.Variable`, which rejects duplicates.

The vectorized edge check also makes `Variable` construction with 100k edges drop
from ~1.2 s to well under a millisecond.

Regression tests were added first and confirmed failing before the fix. The full
suite plus the new tests were run locally on an H100 (CI has no GPU); the only
remaining failure is the pre-existing `test_cpu_conversion` `_ax.metadata` error,
which is being fixed separately.

Part of #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)
