### PR TITLE
chore: drop unused dependencies and simplify internals

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -30,7 +30,7 @@ def tests(session: nox.Session) -> None:
     """
     Run the unit and regular tests.
     """
-    session.install(".[test,dev]")
+    session.install(".[dev]")
     session.run("pytest", *session.posargs)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
   "cupy-cuda12x>=13.1.0",
   "awkward>=2.6.3",
   "numpy>=1.22.0",
-  "scipy>=1.1.0",
   "hist>=2",
   "boost-histogram",
 ]
@@ -47,7 +46,6 @@ dev = [
   "pre-commit",
   "pytest>=6",
   "pytest-cov>=3",
-  "pytest-mpl",
 ]
 docs = [
   "sphinx>=7.0",

--- a/src/cuda_histogram/axis/__init__.py
+++ b/src/cuda_histogram/axis/__init__.py
@@ -68,11 +68,7 @@ class Interval:
             return self._label
         if self.nan():
             return "(nanflow)"
-        return "{}{}, {})".format(
-            "(" if self._lo == -np.inf else "[",
-            self._lo,
-            self._hi,
-        )
+        return f"{'(' if self._lo == -np.inf else '['}{self._lo}, {self._hi})"
 
     def __hash__(self):
         return hash((self._lo, self._hi))
@@ -95,9 +91,7 @@ class Interval:
             return False
         if other.nan() and self.nan():
             return True
-        if self._lo == other._lo and self._hi == other._hi:  # noqa: SIM103
-            return True
-        return False
+        return self._lo == other._lo and self._hi == other._hi
 
     def nan(self):
         return np.isnan(self._hi)
@@ -222,7 +216,7 @@ class Axis:
             return True
         elif isinstance(other, str):
             # Convenient for testing axis in list by name
-            return not self._name != other
+            return self._name == other
         raise TypeError(f"Cannot compare an Axis with a {other!r}")
 
 
@@ -545,11 +539,9 @@ class Bin(DenseAxis):
                 return False
             if self._uniform != other._uniform:
                 return False
-            if self._uniform and self._bins != other._bins:
-                return False
-            if not self._uniform and not all(self._bins == other._bins):  # noqa: SIM103
-                return False
-            return True
+            if self._uniform:
+                return self._bins == other._bins
+            return all(self._bins == other._bins)
         return super().__eq__(other)
 
     def __getitem__(self, index):
@@ -733,9 +725,6 @@ class Regular(Bin):
             hi = self._lo + (islice.stop - 1) * (self._hi - self._lo) / self._bins
             ihi = islice.stop - 1
         bins = ihi - ilo
-        # TODO: remove this once satisfied it works
-        rbins = (hi - lo) * self._bins / (self._hi - self._lo)
-        assert abs(bins - rbins) < 1e-14, "%d %f %r" % (bins, rbins, self)
         return Regular(bins, lo, hi, name=self._name, label=self._label)
 
 

--- a/src/cuda_histogram/hist.py
+++ b/src/cuda_histogram/hist.py
@@ -90,10 +90,7 @@ class Hist:
         self._sumw2 = None
 
     def __repr__(self):
-        repr_str = "Hist("
-        for ax in self._axes:
-            repr_str += f"{ax!r}, "
-        return f"{repr_str[:-2]})"
+        return f"Hist({', '.join(map(repr, self._axes))})"
 
     @property
     def label(self):
@@ -133,9 +130,7 @@ class Hist:
         return self.sparse_axes().index(axis)
 
     def _init_sumw2(self):
-        self._sumw2 = {}
-        for key in self._sumw:
-            self._sumw2[key] = self._sumw[key].copy()
+        self._sumw2 = {key: value.copy() for key, value in self._sumw.items()}
 
     # TODO: should allow better indexing (UHI)
     def __getitem__(self, keys):
@@ -297,7 +292,7 @@ class Hist:
 
         return (
             self._view_dim(cupy.zeros(shape=self._dense_shape), flow)
-            if self._sumw == {}
+            if not self._sumw
             else self._view_dim(next(iter(self._sumw.values())), flow)
         )
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Dependency cleanup plus a few behavior-preserving simplifications.

- Drop `scipy` from the runtime dependencies. It is imported nowhere in `src/`, `tests/`, `docs/`, or `noxfile.py`, and it is a heavy install-weight dependency to carry for nothing.
- Drop `pytest-mpl` from the `dev` extra: no `--mpl`, no `mpl_image_compare` anywhere. This also drops matplotlib and its stack from test environments.
- `nox -s tests` installed `.[test,dev]`, but there is no `test` extra; the test dependencies live in `dev`.
- Internals: direct boolean returns in place of `if cond: return True / return False` (dropping the `# noqa: SIM103` comments), an f-string for `Interval.__str__`, a dict comprehension in `Hist._init_sumw2`, a `", ".join` in `Hist.__repr__`, and removal of a stale TODO plus its `assert` in `Regular.reduced`.

Ran the suite locally on an H100 (CI has no GPU, so `tests/test_hist_tools.py` skips there). Same results before and after: only the pre-existing `test_cpu_conversion` failure, which is unrelated and fixed elsewhere.

Part of #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)
