### PR TITLE
perf: reduce redundant work in fill and index

### DIFF
--- a/src/cuda_histogram/axis/__init__.py
+++ b/src/cuda_histogram/axis/__init__.py
@@ -497,7 +497,7 @@ class Bin(DenseAxis):
             if self._uniform:
                 idx = None
                 if isarray:
-                    idx = cupy.zeros_like(identifier)
+                    idx = cupy.empty_like(identifier)
                     _clip_bins(float(self._bins), self._lo, self._hi, identifier, idx)
                 else:
                     idx = np.clip(
@@ -512,10 +512,9 @@ class Bin(DenseAxis):
                     )
 
                 if isinstance(idx, cupy.ndarray | np.ndarray):
-                    _replace_nans(
-                        self._nanflow_index,
-                        idx if idx.dtype.kind == "f" else idx.astype(cupy.float32),
-                    )
+                    # integer input cannot hold NaN, and the kernel is in-place
+                    if idx.dtype.kind == "f":
+                        _replace_nans(self._nanflow_index, idx)
                     idx = idx.astype(int)
                 elif np.isnan(idx):
                     idx = self._nanflow_index

--- a/src/cuda_histogram/hist.py
+++ b/src/cuda_histogram/hist.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from collections import namedtuple
 
 import cupy
@@ -239,25 +240,22 @@ class Hist:
             xy = cupy.atleast_1d(
                 cupy.ravel_multi_index(dense_indices, self._dense_shape)
             )
+            minlength = math.prod(self._dense_shape)
+
+            def binned(weights):
+                return cupy.bincount(xy, weights=weights, minlength=minlength).reshape(
+                    self._dense_shape
+                )
+
             if weight is not None:
-                self._sumw[sparse_key][:] += cupy.bincount(
-                    xy, weights=weight, minlength=np.array(self._dense_shape).prod()
-                ).reshape(self._dense_shape)
-                self._sumw2[sparse_key][:] += cupy.bincount(
-                    xy,
-                    weights=weight**2,
-                    minlength=np.array(self._dense_shape).prod(),
-                ).reshape(self._dense_shape)
+                self._sumw[sparse_key] += binned(weight)
+                self._sumw2[sparse_key] += binned(weight**2)
             else:
-                self._sumw[sparse_key][:] += cupy.bincount(
-                    xy, weights=None, minlength=np.array(self._dense_shape).prod()
-                ).reshape(self._dense_shape)
+                # counts are the same for both, so only compute them once
+                counts = binned(None)
+                self._sumw[sparse_key] += counts
                 if self._sumw2 is not None:
-                    self._sumw2[sparse_key][:] += cupy.bincount(
-                        xy,
-                        weights=None,
-                        minlength=np.array(self._dense_shape).prod(),
-                    ).reshape(self._dense_shape)
+                    self._sumw2[sparse_key] += counts
         elif weight is not None:
             self._sumw[sparse_key] += cupy.sum(weight)
             self._sumw2[sparse_key] += cupy.sum(weight**2)

--- a/tests/test_hist_tools.py
+++ b/tests/test_hist_tools.py
@@ -174,6 +174,32 @@ def test_bin_validation():
         cuda_histogram.axis.Variable([0, 1, 1, 2])
 
 
+@pytest.mark.parametrize("weighted_first", [False, True])
+def test_mixed_weighted_unweighted_fill(weighted_first):
+    x = cp.array([0.15, 0.25, 0.25, 0.35])
+    w = cp.array([2.0, 3.0, 4.0, 5.0])
+
+    h = cuda_histogram.Hist(cuda_histogram.axis.Regular(4, 0, 1, name="x"))
+    if weighted_first:
+        h.fill(x, weight=w)
+        assert (h.variance() == cp.array([4.0, 50.0, 0.0, 0.0])).all()
+        h.fill(x)
+    else:
+        h.fill(x)
+        assert h.variance() is None
+        h.fill(x, weight=w)
+
+    # an unweighted entry contributes 1 to the variance
+    assert (h.values() == cp.array([3.0, 15.0, 0.0, 0.0])).all()
+    assert (h.variance() == cp.array([5.0, 53.0, 0.0, 0.0])).all()
+
+
+def test_fill_integer_array():
+    h = cuda_histogram.Hist(cuda_histogram.axis.Regular(4, 0, 8, name="x"))
+    h.fill(cp.array([1, 3, 3, 5]))
+    assert (h.values() == cp.array([1.0, 2.0, 1.0, 0.0])).all()
+
+
 def test_cpu_conversion():
     import boost_histogram as bh
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Removes redundant work in the fill path:

- An unweighted `fill()` on a histogram that already tracks variances computed the identical `cupy.bincount` twice (once for `_sumw`, once for `_sumw2`). It is now computed once and added to both.
- `minlength` was rebuilt with `np.array(self._dense_shape).prod()` on every bincount call; it is now `math.prod(...)` computed once.
- The weighted and unweighted branches shared the same bincount/reshape/accumulate structure; they now go through one local helper.
- `Bin.index()` uniform array path: `cupy.zeros_like` -> `cupy.empty_like` (the clip kernel writes every element), and `_replace_nans` is only called for float data. For integer input it was writing into an `astype(cupy.float32)` temporary that was immediately discarded, i.e. a silent no-op plus a full extra allocation per fill.

Behavior is unchanged. Added tests for mixed weighted/unweighted fills in both orders (asserting exact `values()` and `variance()`, where an unweighted entry contributes 1 to the variance) and for integer-array fills.

Benchmarks on an H100, 1e7 float64 elements, `Regular(100, 0, 1)`, mean of 30 synced iterations (before -> after):

| case | before | after |
| --- | --- | --- |
| unweighted fill | 0.64 ms | 0.61 ms |
| unweighted fill, variances already tracked | 1.71 ms | 0.61 ms |
| weighted fill | 8.81 ms | 8.70 ms |
| unweighted fill, integer input array | 1.03 ms | 0.55 ms |

For reference on the same machine, `cupy.histogram` is 0.39 ms unweighted and 4.17 ms weighted, so the weighted path remains dominated by the float atomics in `bincount`.

The full suite was run locally on a GPU (CI has none): 5 passed, with the pre-existing `test_cpu_conversion` `to_boost` failure that is fixed in a separate PR.

Part of #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)
