### PR TITLE
fix: correct binning of integer arrays on axes with non-integral bounds

### DIFF
--- a/src/cuda_histogram/axis/__init__.py
+++ b/src/cuda_histogram/axis/__init__.py
@@ -18,14 +18,16 @@ __all__: list[str] = [
     "Bin",
 ]
 
-_replace_nans = cupy.ElementwiseKernel("T v", "T x", "x = isnan(x)?v:x", "replace_nans")
-
+# bounds are float64 so integer input does not truncate them; NaN maps to nanflow
 _clip_bins = cupy.ElementwiseKernel(
-    "T Nbins, T lo, T hi, T id",
-    "T idx",
+    "float64 nbins, float64 lo, float64 hi, T x",
+    "int64 idx",
     """
-    const T floored = floor((id - lo) * float(Nbins) / (hi - lo)) + 1;
-    idx = floored < 0 ? 0 : (floored > Nbins ? Nbins + 1 : floored);
+    const double floored = floor((x - lo) * nbins / (hi - lo)) + 1;
+    idx = isnan(floored)    ? (long long)nbins + 2
+          : floored < 0     ? 0
+          : floored > nbins ? (long long)nbins + 1
+                            : (long long)floored;
     """,
     "clip_bins",
 )
@@ -495,32 +497,7 @@ class Bin(DenseAxis):
         if isarray or isinstance(identifier, numbers.Number):
             identifier = awkward.to_cupy(identifier)  # cupy.asarray(identifier)
             if self._uniform:
-                idx = None
-                if isarray:
-                    idx = cupy.empty_like(identifier)
-                    _clip_bins(float(self._bins), self._lo, self._hi, identifier, idx)
-                else:
-                    idx = np.clip(
-                        np.floor(
-                            (identifier - self._lo)
-                            * float(self._bins)
-                            / (self._hi - self._lo)
-                        )
-                        + 1,
-                        0,
-                        self._bins + 1,
-                    )
-
-                if isinstance(idx, cupy.ndarray | np.ndarray):
-                    # integer input cannot hold NaN, and the kernel is in-place
-                    if idx.dtype.kind == "f":
-                        _replace_nans(self._nanflow_index, idx)
-                    idx = idx.astype(int)
-                elif np.isnan(idx):
-                    idx = self._nanflow_index
-                else:
-                    idx = int(idx)
-                return idx
+                return _clip_bins(self._bins, self._lo, self._hi, identifier)
             else:
                 return cupy.searchsorted(self._bins, identifier, side="right")
         elif isinstance(identifier, Interval):

--- a/tests/test_hist_tools.py
+++ b/tests/test_hist_tools.py
@@ -200,6 +200,18 @@ def test_fill_integer_array():
     assert (h.values() == cp.array([1.0, 2.0, 1.0, 0.0])).all()
 
 
+def test_fill_integer_array_fractional_bounds():
+    ax = cuda_histogram.axis.Regular(4, 0.5, 8.5)
+    assert (ax.index(cp.array([0, 1, 8, 9])) == cp.array([0, 1, 4, 5])).all()
+    assert (
+        ax.index(cp.array([0, 1, 8, 9])) == ax.index(cp.array([0.0, 1.0, 8.0, 9.0]))
+    ).all()
+
+    h = cuda_histogram.Hist(cuda_histogram.axis.Regular(4, 0.5, 8.5, name="x"))
+    h.fill(cp.array([0, 1, 8, 9]))
+    assert (h.values(flow=True) == cp.array([1.0, 1, 0, 0, 1, 1, 0])).all()
+
+
 def test_cpu_conversion():
     import boost_histogram as bh
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Follow-up 1 from https://github.com/scikit-hep/cuda-histogram/issues/59#issuecomment-5136301811. The mechanism turned out to be slightly different than guessed there: the `_clip_bins` kernel typed all parameters with the single type holder `T`, so for integer input CuPy cast the scalar `lo`/`hi`/`nbins` to the integer type, truncating non-integral bounds before any arithmetic ran. On `Regular(4, 0.5, 8.5)`, an integer fill of `0` landed in the first visible bin instead of underflow, and `8` in overflow instead of bin 4. Integral bounds were unaffected (the `float(Nbins)` cast promoted the arithmetic), which is why the existing integer-fill test passed.

The kernel now takes the bounds as `float64`, computes in double, and emits `int64` indices directly, with NaN mapped to the nanflow bin inside the kernel — which also removes the separate `_replace_nans` kernel launch and the dtype juggling in `Bin.index`.

Regression test added first and confirmed failing; full suite (12 tests) passes locally on an H100 (CI has no GPU).

Part of #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)