### PR TITLE
chore: move dev/docs dependencies to PEP 735 dependency-groups

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,7 +81,7 @@ repos:
         additional_dependencies: ["validate-pyproject-schema-store[all]"]
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: "0.29.2"
+    rev: "0.37.4"
     hooks:
       - id: check-dependabot
       - id: check-github-workflows

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,7 +75,7 @@ repos:
         exclude: .pre-commit-config.yaml
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: "v0.19"
+    rev: "v0.25"
     hooks:
       - id: validate-pyproject
         additional_dependencies: ["validate-pyproject-schema-store[all]"]

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,12 +7,10 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  jobs:
+    post_install:
+      # pip >=25.1 is required for --group
+      - python -m pip install --upgrade pip
+      - python -m pip install --group docs .
 sphinx:
   configuration: docs/conf.py
-
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,13 +4,16 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.11"
-  jobs:
-    post_install:
-      # pip >=25.1 is required for --group
-      - python -m pip install --upgrade pip
-      - python -m pip install --group docs .
+    python: "3.13"
+
+python:
+  install:
+    - method: uv
+      command: sync
+      groups:
+        - docs
+
 sphinx:
   configuration: docs/conf.py

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,8 +8,9 @@ import nox
 
 DIR = Path(__file__).parent.resolve()
 ALL_PYTHON = ["3.10", "3.11", "3.12", "3.13", "3.14"]
+PROJECT = nox.project.load_toml("pyproject.toml")
 
-nox.needs_version = ">=2024.3.2"
+nox.needs_version = ">=2025.2.9"
 nox.options.sessions = ["lint", "tests"]
 nox.options.default_venv_backend = "uv|virtualenv"
 
@@ -30,7 +31,7 @@ def tests(session: nox.Session) -> None:
     """
     Run the unit and regular tests.
     """
-    session.install(".[dev]")
+    session.install(".", *nox.project.dependency_groups(PROJECT, "test"))
     session.run("pytest", *session.posargs)
 
 
@@ -59,7 +60,9 @@ def docs(session: nox.Session) -> None:
 
     extra_installs = ["sphinx-autobuild"] if args.serve else []
 
-    session.install("-e.[docs]", *extra_installs)
+    session.install(
+        "-e.", *nox.project.dependency_groups(PROJECT, "docs"), *extra_installs
+    )
     session.chdir("docs")
 
     if args.builder == "linkcheck":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,9 +41,8 @@ dependencies = [
   "hist>=2",
   "boost-histogram",
 ]
-[project.optional-dependencies]
-dev = [
-  "pre-commit",
+[dependency-groups]
+test = [
   "pytest>=6",
   "pytest-cov>=3",
 ]
@@ -53,6 +52,9 @@ docs = [
   "sphinx_copybutton",
   "sphinx_autodoc_typehints",
   "furo>=2023.08.17",
+]
+dev = [
+  { include-group = "test" },
 ]
 
 [project.urls]
@@ -65,11 +67,6 @@ Changelog = "https://github.com/scikit-hep/cuda-histogram/releases"
 [tool.hatch]
 version.source = "vcs"
 build.hooks.vcs.version-file = "src/cuda_histogram/_version.py"
-
-[tool.hatch.envs.default]
-features = ["test"]
-scripts.test = "pytest {args}"
-
 
 [tool.pytest.ini_options]
 minversion = "6.0"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Moves `dev` and `docs` from `[project.optional-dependencies]` to `[dependency-groups]`, reserving extras for public, user-facing installs (of which there are currently none). Groups are `test`, `docs`, and `dev = [{include-group = "test"}]`, so `uv run pytest` now works with no flags (uv installs the `dev` group by default).

- `noxfile.py` resolves groups via `nox.project.dependency_groups` (requires nox >= 2025.2.9), which expands to plain requirement strings — no minimum pip version needed in session venvs.
- Read the Docs uses its native uv install method (`method: uv` with `groups: [docs]`), on the ubuntu-24.04 / Python 3.13 image from the documented example.
- Removes the vestigial `[tool.hatch.envs.default]` block that referenced the nonexistent `test` extra (follow-up 2 from the issue comment).
- Bumps `validate-pyproject` v0.19 → v0.25 (understands `dependency-groups`) and `check-jsonschema` 0.29.2 → 0.37.4 (RTD schema that knows the uv method and Python 3.13).
- `pre-commit` is no longer in the default dev environment; the nox `lint` session installs it itself.

Verified locally on an H100: `uv run pytest` (11 passed, fresh env), `nox -s tests-3.12`, and `nox -s docs` all succeed; prek clean. The RTD build itself will verify on the PR's docs build.

Part of #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)