### PR TITLE
chore: use extras for CuPy CUDA versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ as well as on [conda](https://anaconda.org/conda-forge/cuda_histogram). The
 library can be installed using `pip` -
 
 ```
-pip install cuda-histogram
+pip install cuda-histogram[cuda13x]
 ```
 
 or using `conda` -
@@ -58,6 +58,10 @@ or using `conda` -
 ```
 conda install -c conda-forge cuda_histogram
 ```
+
+The `cuda13x` extra pulls in `cupy-cuda13x` (CUDA 13); use `cuda12x` instead if
+you have CUDA 12. Installing without an extra leaves CuPy to you, which is what
+you want if you already have a CuPy build (from conda or built from source).
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,12 +35,16 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-  "cupy-cuda12x>=13.1.0",
   "awkward>=2.6.3",
   "numpy>=1.22.0",
   "hist>=2",
   "boost-histogram",
 ]
+
+[project.optional-dependencies]
+cuda12x = ["cupy-cuda12x>=13.1.0"]
+cuda13x = ["cupy-cuda13x>=13.6.0"]
+
 [dependency-groups]
 test = [
   "pytest>=6",
@@ -62,6 +66,11 @@ Homepage = "https://github.com/scikit-hep/cuda-histogram"
 "Bug Tracker" = "https://github.com/scikit-hep/cuda-histogram/issues"
 Discussions = "https://github.com/scikit-hep/cuda-histogram/discussions"
 Changelog = "https://github.com/scikit-hep/cuda-histogram/releases"
+
+
+[tool.uv]
+# Both wheels install the `cupy` package, so only one may be present
+conflicts = [[{ extra = "cuda12x" }, { extra = "cuda13x" }]]
 
 
 [tool.hatch]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

CuPy moves out of the hard dependencies and into extras, one per CUDA major version:

- `cuda-histogram[cuda13x]` → `cupy-cuda13x>=13.6.0` (first release of that wheel)
- `cuda-histogram[cuda12x]` → `cupy-cuda12x>=13.1.0`

Installing with no extra leaves CuPy to the user, which is what you want with a conda or source CuPy build. The two extras are declared as conflicting under `[tool.uv]`, since both wheels install the same `cupy` package (so `uv sync --all-extras` now errors by design; use `--extra cuda13x`).

Verified on an H100 with a CUDA 13.3 driver, Python 3.13: both extras pass the full suite, and the no-extra install skips the CuPy tests as intended. `cupy-cuda13x` ships cp310–cp314 wheels, covering the project's whole supported range.

CI and `noxfile.py` still install plain `.`, so runners no longer download a ~130 MB CuPy wheel just to skip the GPU tests.
