### PR TITLE
ci: add a self-hosted CUDA runner workflow

### DIFF
--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -1,0 +1,68 @@
+name: GPU
+
+on:
+  schedule:
+    - cron: "37 5 * * *"
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+env:
+  FORCE_COLOR: 3
+
+jobs:
+  gpu-tests:
+    name: CUDA ${{ matrix.cuda-version }}
+    if:
+      github.event_name != 'schedule' || github.repository_owner == 'scikit-hep'
+    runs-on: self-hosted
+    timeout-minutes: 60
+
+    # Required for micromamba to activate conda
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        cuda-version:
+          - 12
+          - 13
+
+    steps:
+      - name: Clean the workspace and micromamba
+        run: |
+          rm -rf * .[!.]* || echo "Nothing to clean"
+          rm -rf ~/micromamba* || echo "Nothing to clean"
+
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: mamba-org/setup-micromamba@v3
+        with:
+          environment-name: test-env
+          init-shell: bash
+          create-args: >-
+            python=3.13 cupy>=13.1 cuda-version=${{ matrix.cuda-version }}
+
+      - name: Install cuda-histogram and test dependencies
+        # CuPy comes from conda-forge here, so no cudaNNx extra is selected.
+        run: |
+          python -m pip install -v . pytest pytest-github-actions-annotate-failures
+
+      - name: Print versions
+        run: python -m pip list
+
+      - name: Run the GPU tests
+        run: python -m pytest -vv -rs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,8 @@ sphinx-apidoc).
 Dev/test/docs dependencies live in PEP 735 `[dependency-groups]` (`test`,
 `docs`, `dev` includes `test`); nox resolves them via
 `nox.project.dependency_groups`. Extras are reserved for public, user-facing
-options and there are currently none.
+options: `cuda12x` and `cuda13x` select the matching CuPy wheel, and they
+conflict, so select exactly one.
 
 ## Testing reality
 
@@ -28,6 +29,11 @@ entirely there (`pytest.importorskip("cupy")` plus a `getDeviceCount` check).
 `tests/test_dummy.py` exists only so pytest doesn't fail on an empty collection.
 Real coverage only happens on a CUDA machine — run the suite locally before
 claiming a change works.
+
+`.github/workflows/gpu.yml` runs the full suite on the scikit-hep self-hosted
+runners (nightly, on pushes to `main`, and on demand), matrixed over CUDA 12
+and 13. It gets CuPy from conda-forge with micromamba, so it installs the
+package without a `cuda12x`/`cuda13x` extra.
 
 `filterwarnings = ["error", ...]` in `pyproject.toml`, so unexpected warnings
 fail tests. mypy is configured strict but its pre-commit hook is commented out,


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds `.github/workflows/gpu.yml`, which runs the full test suite on the scikit-hep self-hosted runners: nightly, on pushes to `main`, and on demand. The matrix covers CUDA 12 and 13.

CuPy comes from conda-forge through micromamba, so the install does not select a `cuda12x` or `cuda13x` extra. This follows the same pattern as the GPU workflows in awkward and vector.

`AGENTS.md` gets a note about the new workflow, and its "no extras" line is corrected, because #68 added the CuPy extras.