### PR TITLE
ci: run the GPU workflow on same-repo PRs

### DIFF
--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
   workflow_dispatch:
 
 permissions:
@@ -21,8 +22,11 @@ env:
 jobs:
   gpu-tests:
     name: CUDA ${{ matrix.cuda-version }}
-    if:
-      github.event_name != 'schedule' || github.repository_owner == 'scikit-hep'
+    # Self-hosted runners must not run code from forks.
+    if: >-
+      (github.event_name != 'schedule' || github.repository_owner ==
+      'scikit-hep') && (github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: self-hosted
     timeout-minutes: 60
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Add a `pull_request` trigger to the GPU workflow, with a job-level guard so it only runs when the head branch is in this repository. Fork PRs create the check but skip the job, so untrusted code never runs on the self-hosted runners.

The existing concurrency block already cancels superseded runs on `refs/pull/...`.