### PR TITLE
chore: update pre-commit hooks and fix new ruff checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,7 +79,7 @@ repos:
     hooks:
       - id: validate-pyproject
         additional_dependencies:
-          ["validate-pyproject-schema-store[all]==2026.07.28"]
+          - "validate-pyproject-schema-store[all]==2026.07.28"
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: "0.37.4"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,14 +4,14 @@ ci:
 
 repos:
   - repo: https://github.com/adamchainz/blacken-docs
-    rev: "1.18.0"
+    rev: "1.20.0"
     hooks:
       - id: blacken-docs
         args: ["-E"]
         additional_dependencies: [black==24.*]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v4.6.0"
+    rev: "v6.0.0"
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -34,17 +34,17 @@ repos:
       - id: rst-inline-touching-normal
 
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: "v3.3.3"
+    rev: "v3.9.6"
     hooks:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json]
         args: [--prose-wrap=always]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.6.2"
+    rev: "v0.16.1"
     hooks:
-      - id: ruff
-        args: ["--fix", "--show-fixes"]
+      - id: ruff-check
+        args: ["--fix"]
       - id: ruff-format
 
   # - repo: https://github.com/pre-commit/mirrors-mypy
@@ -57,12 +57,12 @@ repos:
   #         - pytest
 
   - repo: https://github.com/codespell-project/codespell
-    rev: "v2.3.0"
+    rev: "v2.4.3"
     hooks:
       - id: codespell
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: "v0.10.0.1"
+    rev: "v0.11.0.1"
     hooks:
       - id: shellcheck
 
@@ -78,7 +78,8 @@ repos:
     rev: "v0.25"
     hooks:
       - id: validate-pyproject
-        additional_dependencies: ["validate-pyproject-schema-store[all]"]
+        additional_dependencies:
+          ["validate-pyproject-schema-store[all]==2026.07.28"]
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: "0.37.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,8 @@ disallow_incomplete_defs = true
 
 
 [tool.ruff]
+show-fixes = true
+
 [tool.ruff.lint]
 extend-select = [
   "B",        # flake8-bugbear
@@ -145,9 +147,7 @@ ignore = [
   "PLR09",    # Too many <...>
   "PLR2004",  # Magic value used in comparison
   "ISC001",   # Conflicts with formatter
-  "EM101",    # Exception must not use an f-string literal
-  "EM102",    # Exception must not use an f-string literal
-  "EM102",    # Exception must not use an f-string literal
+  "EM101",    # Exception must not use a string literal
   "EM102",    # Exception must not use an f-string literal
   "EM103",    # Exception must not use a `.format()` string directly
   "RET505",   # Unnecessary `elif` after `return` statement
@@ -160,11 +160,9 @@ ignore = [
   "NPY002",   # Legacy numpy functions
 ]
 isort.required-imports = ["from __future__ import annotations"]
-# Uncomment if using a _compat.typing backport
-# typing-modules = ["cuda_histogram._compat.typing"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["T20"]
+"tests/**" = ["T20", "PLC0415"]
 "noxfile.py" = ["T20"]
 
 

--- a/src/cuda_histogram/__init__.py
+++ b/src/cuda_histogram/__init__.py
@@ -14,6 +14,6 @@ from cuda_histogram.hist import Hist
 
 __all__: list[str] = [
     "Hist",
-    "axis",
     "__version__",
+    "axis",
 ]

--- a/src/cuda_histogram/_version.pyi
+++ b/src/cuda_histogram/_version.pyi
@@ -1,4 +1,2 @@
-from __future__ import annotations
-
 version: str
 version_tuple: tuple[int, int, int] | tuple[int, int, int, str, str]

--- a/src/cuda_histogram/axis/__init__.py
+++ b/src/cuda_histogram/axis/__init__.py
@@ -10,12 +10,12 @@ import cupy
 import numpy as np
 
 __all__: list[str] = [
-    "Regular",
-    "Variable",
+    "Bin",
     # "Cat",
     "Interval",
+    "Regular",
     # "StringBin",
-    "Bin",
+    "Variable",
 ]
 
 # bounds are float64 so integer input does not truncate them; NaN maps to nanflow
@@ -208,6 +208,8 @@ class Axis:
     @label.setter
     def label(self, label):
         self._label = label
+
+    __hash__ = None  # mutable label, and __eq__ also accepts str
 
     def __eq__(self, other):
         if isinstance(other, Axis):
@@ -516,6 +518,8 @@ class Bin(DenseAxis):
                 f"Axis {self!r} has no interval that fully contains identifier {identifier!r}"
             )
         raise TypeError("Request bin indices with a identifier or 1-D array only")
+
+    __hash__ = None
 
     def __eq__(self, other):
         if isinstance(other, DenseAxis):

--- a/src/cuda_histogram/hist.py
+++ b/src/cuda_histogram/hist.py
@@ -347,8 +347,8 @@ class Hist:
         Appropriate boost-histogram axis and storage are automatically chosen.
         All the arguments of cuda-histogram's axis and histogram are passed down.
         """
-        import boost_histogram
-        import hist
+        import boost_histogram  # noqa: PLC0415
+        import hist  # noqa: PLC0415
 
         # hist's axes subclass boost-histogram's and carry name/label properly
         newaxes = []
@@ -435,6 +435,6 @@ class Hist:
 
     def to_hist(self):
         """Convert this cuda_histogram object to a hist object"""
-        import hist
+        import hist  # noqa: PLC0415
 
         return hist.Hist(self.to_boost(), name=self.name)

--- a/tests/test_hist_tools.py
+++ b/tests/test_hist_tools.py
@@ -5,7 +5,7 @@ import pytest
 
 cp = pytest.importorskip("cupy")
 
-import cuda_histogram  # noqa: E402
+import cuda_histogram
 
 # cupy might be installable on a device with no GPUs
 try:
@@ -26,7 +26,7 @@ def dummy_jagged_eta_pt():
 
 
 def test_hist():
-    counts, test_eta, test_pt = dummy_jagged_eta_pt()
+    _counts, test_eta, test_pt = dummy_jagged_eta_pt()
 
     h = cuda_histogram.Hist(
         cuda_histogram.axis.Regular(20, 0, 2, label="x", name="x"),
@@ -112,7 +112,7 @@ def test_hist():
 
 
 def test_partial_indexing():
-    counts, test_eta, test_pt = dummy_jagged_eta_pt()
+    _counts, test_eta, test_pt = dummy_jagged_eta_pt()
 
     h = cuda_histogram.Hist(
         cuda_histogram.axis.Regular(20, 0, 2, label="x", name="x"),


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Renames the `ruff` hook to `ruff-check` (the old name is deprecated), moves `--show-fixes` into `[tool.ruff]`, and pins the validate-pyproject schema store.

Fixes what the newer ruff rules report:

- sorts `__all__` in `cuda_histogram.axis`
- adds an explicit `__hash__ = None` to `Axis` and `Bin`, which only states what Python already does for a class with `__eq__` (PLW1641)
- allows the deliberate lazy imports of `hist`/`boost_histogram` (PLC0415)
- renames an unused test variable

Also removes duplicate entries from the ruff ignore list.