### PR TITLE
feat: add a StrCategory axis, restoring categorical support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,11 +49,10 @@ retrofitted onto a boost-histogram-like public API.
 sparse-axis indices) to a dense CuPy array of shape `Hist._dense_shape`.
 `_sumw2` stays `None` until the first weighted `fill()`, at which point
 `_init_sumw2()` seeds it from `_sumw`; `variance()` returns `None` while it is
-`None`, and `to_boost()` picks `Double` vs `Weight` storage from it. Sparse axes
-(`Cat`, `StringBin`) are commented out throughout both modules pending a
-refactor to match boost-histogram's `StrCategory`, so in practice the only key
-is `()`. Leave those comment blocks alone — restoring them is a stated roadmap
-item.
+`None`, and `to_boost()` picks `Double` vs `Weight` storage from it. The sparse
+key holds one bin index per `StrCategory` axis (empty tuple when there are
+none); `values()`/`variance()` stack the sparse dict into a dense array via
+`Hist._stack_sparse`, reordering so category dimensions land in axis order.
 
 **Bin layout.** Every dense axis stores `nbins + 3` bins: index `0` = underflow,
 `n+1` = overflow, `n+2` = **nanflow**. The nanflow bin is the main deviation
@@ -62,12 +61,13 @@ and `size + 1` for `Variable` — these agree because `Variable.size` counts the
 extra `inf` edge appended in `Bin.__init__`. `_overflow_behavior(flow)` is the
 single place that translates `flow=False` into `slice(1, -2)`.
 
-**Filling.** `Hist.fill()` requires CuPy arrays. It maps values to indices via
-`axis.index()`, flattens with `cupy.ravel_multi_index`, and accumulates with
-`cupy.bincount`. Uniform (`Regular`) axes compute indices with the `_clip_bins`
-`cupy.ElementwiseKernel` at the top of `axis/__init__.py` (clamps to the flow
-bins and sends NaN to nanflow); `Variable` axes use `cupy.searchsorted` against
-edges with `inf` appended so NaN sorts past it.
+**Filling.** `Hist.fill()` requires CuPy arrays (a plain string per
+`StrCategory` axis). It maps values to indices via `axis.index()`, flattens with
+`cupy.ravel_multi_index`, and accumulates with `cupy.bincount`. Uniform
+(`Regular`) axes compute indices with the `_clip_bins` `cupy.ElementwiseKernel`
+at the top of `axis/__init__.py` (clamps to the flow bins and sends NaN to
+nanflow); `Variable` axes use `cupy.searchsorted` against edges with `inf`
+appended so NaN sorts past it.
 
 **Indexing.** `Hist.__getitem__` is deliberately narrow: indices are _values in
 bin-edge coordinates_, not integer bin numbers, no interpolation (a
@@ -87,5 +87,5 @@ survive.
 ## Conventions
 
 - `from __future__ import annotations` is a required first import (ruff isort).
-- The package is Regular/Variable-only by design; when adding features, check
-  whether boost-histogram already names the concept and match that name.
+- Axes are `Regular`, `Variable`, and `StrCategory` only; when adding features,
+  check whether boost-histogram already names the concept and match that name.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,16 +24,19 @@ conflict, so select exactly one.
 
 ## Testing reality
 
-CI runs on `ubuntu-latest` with **no GPU**, so `tests/test_hist_tools.py` skips
-entirely there (`pytest.importorskip("cupy")` plus a `getDeviceCount` check).
-`tests/test_dummy.py` exists only so pytest doesn't fail on an empty collection.
-Real coverage only happens on a CUDA machine — run the suite locally before
-claiming a change works.
+`.github/workflows/ci.yml` runs on `ubuntu-latest` with **no GPU**, so
+`tests/test_hist_tools.py` skips entirely there (`pytest.importorskip("cupy")`
+plus a `getDeviceCount` check). `tests/test_dummy.py` exists only so pytest
+doesn't fail on an empty collection.
 
-`.github/workflows/gpu.yml` runs the full suite on the scikit-hep self-hosted
-runners (nightly, on pushes to `main`, and on demand), matrixed over CUDA 12
-and 13. It gets CuPy from conda-forge with micromamba, so it installs the
-package without a `cuda12x`/`cuda13x` extra.
+Real coverage comes from `.github/workflows/gpu.yml`, which runs the full suite
+on the scikit-hep self-hosted CUDA runners, matrixed over CUDA 12/13 and Python
+3.10/3.14 (oldest and newest supported). It triggers nightly, on pushes to
+`main`, on demand, and on pull requests — but only same-repo PRs, since
+self-hosted runners must not run fork code. It gets CuPy from conda-forge with
+micromamba, so it installs the package without a `cuda12x`/`cuda13x` extra.
+Still run the suite locally on a CUDA machine before claiming a change works;
+PRs from a fork get no GPU coverage at all.
 
 `filterwarnings = ["error", ...]` in `pyproject.toml`, so unexpected warnings
 fail tests. mypy runs strict via pre-commit (`uv run mypy` locally); `cupy` and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,9 @@ sparse-axis indices) to a dense CuPy array of shape `Hist._dense_shape`.
 `_init_sumw2()` seeds it from `_sumw`; `variance()` returns `None` while it is
 `None`, and `to_boost()` picks `Double` vs `Weight` storage from it. The sparse
 key holds one bin index per `StrCategory` axis (empty tuple when there are
-none); `values()`/`variance()` stack the sparse dict into a dense array via
+none); index `size` is the overflow bin of a non-growing `overflow=True` axis,
+and unmatched fills on an `overflow=False` axis are discarded entirely.
+`values()`/`variance()` stack the sparse dict into a dense array via
 `Hist._stack_sparse`, reordering so category dimensions land in axis order.
 
 **Bin layout.** Every dense axis stores `nbins + 3` bins: index `0` = underflow,

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Main features of cuda-histogram:
       - `centers()`
       - `index(...)`
       - ...
+    - `StrCategory` axis (with sparse storage and optional `growth`)
   - Histogram
     - `fill(..., weight=...)` (including `Nan` flow)
     - simple indexing with slicing (see example below)
@@ -39,8 +40,6 @@ Main features of cuda-histogram:
 
 Near future goals for the package -
 
-- Implement support for `Categorical` axes (exists internally but need
-  refactoring to match boost-histogram's API)
 - Improve indexing (`__getitem__`) to exactly match boost-histogram's API
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Main features of cuda-histogram:
       - `centers()`
       - `index(...)`
       - ...
-    - `StrCategory` axis (with sparse storage and optional `growth`)
+    - `StrCategory` axis (sparse storage, with boost-histogram's `growth` and
+      `overflow` behaviors)
   - Histogram
     - `fill(..., weight=...)` (including `Nan` flow)
     - simple indexing with slicing (see example below)

--- a/src/cuda_histogram/axis/__init__.py
+++ b/src/cuda_histogram/axis/__init__.py
@@ -12,10 +12,9 @@ import numpy as np
 
 __all__: list[str] = [
     "Bin",
-    # "Cat",
     "Interval",
     "Regular",
-    # "StringBin",
+    "StrCategory",
     "Variable",
 ]
 
@@ -123,68 +122,6 @@ class Interval:
         self._label = lbl
 
 
-# TODO: cleanup logic for sparse axis
-# @functools.total_ordering
-# class StringBin:
-#     """A string used to fill a sparse axis
-
-#     Totally ordered, lexicographically by name.
-
-#     Parameters
-#     ----------
-#         name : str
-#             Name of the bin, as used in `Hist.fill` calls
-#         label : str
-#             The `str` representation of this bin can be overridden by
-#             a custom label.
-#     """
-
-#     def __init__(self, name, label=None):
-#         if not isinstance(name, str):
-#             raise TypeError(
-#                 f"StringBin only supports string categories, received a {name!r}"
-#             )
-#         elif "*" in name:
-#             raise ValueError(
-#                 "StringBin does not support character '*' as it conflicts with wildcard mapping."
-#             )
-#         self._name = name
-#         self._label = label
-
-#     def __repr__(self):
-#         return f"<{self.__class__.__name__} ({self.name}) instance at 0x{id(self):0x}>"
-
-#     def __str__(self):
-#         if self._label is not None:
-#             return self._label
-#         return self._name
-
-#     def __hash__(self):
-#         return hash(self._name)
-
-#     def __lt__(self, other):
-#         return self._name < other._name
-
-#     def __eq__(self, other):
-#         if isinstance(other, StringBin):
-#             return self._name == other._name
-#         return False
-
-#     @property
-#     def name(self):
-#         """Name of this bin, *Immutable*"""
-#         return self._name
-
-#     @property
-#     def label(self):
-#         """Label of this bin, mutable"""
-#         return self._label
-
-#     @label.setter
-#     def label(self, lbl):
-#         self._label = lbl
-
-
 class Axis:
     """
     Axis: Base class for any type of axis
@@ -235,144 +172,151 @@ class SparseAxis(Axis):
 
         **__getitem__(index)** - return an identifier
 
-        **_ireduce(slice)** - return a list of hashes, slice is arbitrary
+        **_ireduce(slice)** - return a list of bin indices, slice is arbitrary
 
-    What we really want here is a hashlist with some slice sugar on top
-    It is usually the case that the identifier is already hashable,
-    in which case index and __getitem__ are trivial, but this mechanism
-    may be useful if the size of the tuple of identifiers in a
-    sparse-binned histogram becomes too large
+        **reduced(indices)** - return a new axis with only the given bins
     """
 
     def index(self, identifier: Any) -> Any:
         raise NotImplementedError
 
-    def _ireduce(self, the_slice: Any) -> Any:
+    def _ireduce(self, the_slice: Any) -> list[int]:
+        raise NotImplementedError
+
+    def reduced(self, indices: list[int]) -> SparseAxis:
+        raise NotImplementedError
+
+    @property
+    def size(self) -> int:
+        """Number of bins"""
         raise NotImplementedError
 
 
-# TODO: cleanup logic for sparse axis
-# class Cat(SparseAxis):
-#     """A category axis with name and label
+class StrCategory(SparseAxis):
+    """A categorical axis with string-valued bins.
 
-#     Parameters
-#     ----------
-#         name : str
-#             is used as a keyword in histogram filling, immutable
-#         label : str
-#             describes the meaning of the axis, can be changed
-#         sorting : {'identifier', 'placement', 'integral'}, optional
-#             Axis sorting when listing identifiers.
+    Modeled on ``boost_histogram.axis.StrCategory``. Categories are kept in
+    insertion order, and histogram storage is sparse: only filled categories
+    occupy memory.
 
-#     The number of categories is arbitrary, and can be filled sparsely
-#     Identifiers are strings
-#     """
+    Parameters
+    ----------
+        categories : Iterable[str]
+            Initial categories, in bin order.
+        name : str
+            is used as a keyword in histogram filling, immutable
+        label : str
+            describes the meaning of the axis, can be changed
+        growth : bool
+            If True, filling a category not on the axis appends it instead
+            of raising ``KeyError``.
+    """
 
-#     def __init__(self, name, label, sorting="identifier"):
-#         super().__init__(name, label)
-#         # In all cases key == value.name
-#         self._bins = {}
-#         self._sorting = sorting
-#         self._sorted = []
+    def __init__(
+        self,
+        categories: Iterable[str] = (),
+        *,
+        name: str = "",
+        label: str = "",
+        growth: bool = False,
+    ) -> None:
+        super().__init__(name, label)
+        self._indices: dict[str, int] = {}
+        self._growth = growth
+        for category in categories:
+            self._add(category)
 
-#     def index(self, identifier):
-#         """Index of a identifier or label
+    def _add(self, category: str) -> int:
+        if not isinstance(category, str):
+            raise TypeError(
+                f"StrCategory only supports string categories, received {category!r}"
+            )
+        if category in self._indices:
+            raise ValueError(f"Duplicate category {category!r}")
+        index = len(self._indices)
+        self._indices[category] = index
+        return index
 
-#         Parameters
-#         ----------
-#             identifier : str or StringBin
-#                 The identifier to lookup
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({list(self._indices)})"
 
-#         Returns a `StringBin` corresponding to the given argument (trivial in the case
-#         where a `StringBin` was passed) and saves a reference internally in the case where
-#         the identifier was not seen before by this axis.
-#         """
-#         if isinstance(identifier, StringBin):
-#             index = identifier
-#         else:
-#             index = StringBin(identifier)
-#         if index.name not in self._bins:
-#             self._bins[index.name] = index
-#             self._sorted.append(index.name)
-#             if self._sorting == "identifier":
-#                 self._sorted.sort()
-#         return self._bins[index.name]
+    @property
+    def growth(self) -> bool:
+        """Whether filling an unknown category appends it to the axis"""
+        return self._growth
 
-#     def __eq__(self, other):
-#         # Sparse, so as long as name is the same
-#         return super().__eq__(other)
+    @property
+    def size(self) -> int:
+        """Number of categories"""
+        return len(self._indices)
 
-#     def __getitem__(self, index):
-#         if not isinstance(index, StringBin):
-#             raise TypeError(f"Expected a StringBin object, got: {index!r}")
-#         identifier = index.name
-#         if identifier not in self._bins:
-#             raise KeyError("No identifier %r in this Category axis")
-#         return identifier
+    def index(self, identifier: str) -> int:
+        """Index of a category
 
-#     def _ireduce(self, the_slice):
-#         out = None
-#         if isinstance(the_slice, StringBin):
-#             out = [the_slice.name]
-#         elif isinstance(the_slice, re.Pattern):
-#             out = [k for k in self._sorted if the_slice.match(k)]
-#         elif isinstance(the_slice, str):
-#             pattern = "^" + re.escape(the_slice).replace(r"\*", ".*") + "$"
-#             m = re.compile(pattern)
-#             out = [k for k in self._sorted if m.match(k)]
-#         elif isinstance(the_slice, list):
-#             if not all(k in self._sorted for k in the_slice):
-#                 warnings.warn(
-#                     f"Not all requested indices present in {self!r}", RuntimeWarning
-#                 )
-#             out = [k for k in self._sorted if k in the_slice]
-#         elif isinstance(the_slice, slice):
-#             if the_slice.step is not None:
-#                 raise IndexError("Not sure how to use slice step for categories...")
-#             start, stop = 0, len(self._sorted)
-#             if isinstance(the_slice.start, str):
-#                 start = self._sorted.index(the_slice.start)
-#             else:
-#                 start = the_slice.start
-#             if isinstance(the_slice.stop, str):
-#                 stop = self._sorted.index(the_slice.stop)
-#             else:
-#                 stop = the_slice.stop
-#             out = self._sorted[start:stop]
-#         else:
-#             raise IndexError(f"Cannot understand slice {the_slice!r} on axis {self!r}")
-#         return [self._bins[k] for k in out]
+        Parameters
+        ----------
+            identifier : str
+                The category to look up.
 
-#     @property
-#     def size(self):
-#         """Number of bins"""
-#         return len(self._bins)
+        Returns the integer bin index of the category. If the axis was
+        constructed with ``growth=True``, an unknown category is appended
+        instead of raising ``KeyError``.
+        """
+        if not isinstance(identifier, str):
+            raise TypeError(
+                f"StrCategory only supports string categories, received {identifier!r}"
+            )
+        if identifier not in self._indices:
+            if not self._growth:
+                raise KeyError(
+                    f"No category {identifier!r} in axis {self!r} (pass growth=True to add categories when filling)"
+                )
+            return self._add(identifier)
+        return self._indices[identifier]
 
-#     @property
-#     def sorting(self):
-#         """Sorting definition to adhere to
+    def __getitem__(self, index: int) -> str:
+        return list(self._indices)[index]
 
-#         See `Cat` constructor for possible values
-#         """
-#         return self._sorting
+    def _ireduce(self, the_slice: Any) -> list[int]:
+        if isinstance(the_slice, str):
+            if the_slice not in self._indices:
+                raise KeyError(f"No category {the_slice!r} in axis {self!r}")
+            out = [the_slice]
+        elif isinstance(the_slice, list):
+            if not all(k in self._indices for k in the_slice):
+                warnings.warn(
+                    f"Not all requested categories present in {self!r}", RuntimeWarning
+                )
+            out = [k for k in the_slice if k in self._indices]
+        elif isinstance(the_slice, slice):
+            if the_slice != slice(None):
+                raise IndexError(
+                    f"Cannot understand slice {the_slice!r} on axis {self!r}"
+                )
+            out = list(self._indices)
+        else:
+            raise IndexError(f"Cannot understand slice {the_slice!r} on axis {self!r}")
+        return [self._indices[k] for k in out]
 
-#     @sorting.setter
-#     def sorting(self, newsorting):
-#         if newsorting == "placement":
-#             # not much we can do about already inserted values
-#             pass
-#         elif newsorting == "identifier":
-#             self._sorted.sort()
-#         elif newsorting == "integral":
-#             # this will be checked in any Hist.identifiers() call accessing this axis
-#             pass
-#         else:
-#             raise AttributeError(f"Invalid axis sorting type: {newsorting}")
-#         self._sorting = newsorting
+    def reduced(self, indices: list[int]) -> StrCategory:
+        """Return a new axis with only the categories at the given indices
 
-#     def identifiers(self):
-#         """List of `StringBin` identifiers"""
-#         return [self._bins[k] for k in self._sorted]
+        Parameters
+        ----------
+            indices : list[int]
+                Category indices, usually as returned from ``StrCategory._ireduce``
+        """
+        categories = list(self._indices)
+        return StrCategory(
+            [categories[i] for i in indices],
+            name=self._name,
+            label=self._label,
+            growth=self._growth,
+        )
+
+    def identifiers(self) -> list[str]:
+        """List of string categories"""
+        return list(self._indices)
 
 
 class DenseAxis(Axis):

--- a/src/cuda_histogram/axis/__init__.py
+++ b/src/cuda_histogram/axis/__init__.py
@@ -188,7 +188,12 @@ class SparseAxis(Axis):
 
     @property
     def size(self) -> int:
-        """Number of bins"""
+        """Number of bins, not counting the overflow bin"""
+        raise NotImplementedError
+
+    @property
+    def overflow(self) -> bool:
+        """Whether unmatched fills are counted in a trailing overflow bin"""
         raise NotImplementedError
 
 
@@ -208,8 +213,11 @@ class StrCategory(SparseAxis):
         label : str
             describes the meaning of the axis, can be changed
         growth : bool
-            If True, filling a category not on the axis appends it instead
-            of raising ``KeyError``.
+            If True, filling a category not on the axis appends it; a growing
+            axis matches everything, so it has no overflow bin.
+        overflow : bool
+            If True (and not growing), unmatched fills are counted in a
+            trailing overflow bin; if False they are discarded.
     """
 
     def __init__(
@@ -219,10 +227,12 @@ class StrCategory(SparseAxis):
         name: str = "",
         label: str = "",
         growth: bool = False,
+        overflow: bool = True,
     ) -> None:
         super().__init__(name, label)
         self._indices: dict[str, int] = {}
         self._growth = growth
+        self._overflow = overflow and not growth
         for category in categories:
             self._add(category)
 
@@ -246,11 +256,16 @@ class StrCategory(SparseAxis):
         return self._growth
 
     @property
+    def overflow(self) -> bool:
+        """Whether unmatched fills are counted in a trailing overflow bin"""
+        return self._overflow
+
+    @property
     def size(self) -> int:
-        """Number of categories"""
+        """Number of categories, not counting the overflow bin"""
         return len(self._indices)
 
-    def index(self, identifier: str) -> int:
+    def index(self, identifier: str) -> int | None:
         """Index of a category
 
         Parameters
@@ -258,20 +273,19 @@ class StrCategory(SparseAxis):
             identifier : str
                 The category to look up.
 
-        Returns the integer bin index of the category. If the axis was
-        constructed with ``growth=True``, an unknown category is appended
-        instead of raising ``KeyError``.
+        Returns the integer bin index of the category. An unknown category
+        is appended if the axis was constructed with ``growth=True``;
+        otherwise it maps to the overflow bin (index ``size``), or to
+        ``None`` (meaning: discard) if ``overflow=False``.
         """
         if not isinstance(identifier, str):
             raise TypeError(
                 f"StrCategory only supports string categories, received {identifier!r}"
             )
         if identifier not in self._indices:
-            if not self._growth:
-                raise KeyError(
-                    f"No category {identifier!r} in axis {self!r} (pass growth=True to add categories when filling)"
-                )
-            return self._add(identifier)
+            if self._growth:
+                return self._add(identifier)
+            return self.size if self._overflow else None
         return self._indices[identifier]
 
     def __getitem__(self, index: int) -> str:
@@ -312,6 +326,7 @@ class StrCategory(SparseAxis):
             name=self._name,
             label=self._label,
             growth=self._growth,
+            overflow=self._overflow,
         )
 
     def identifiers(self) -> list[str]:

--- a/src/cuda_histogram/axis/__init__.py
+++ b/src/cuda_histogram/axis/__init__.py
@@ -147,6 +147,11 @@ class Axis:
     def label(self, label: str) -> None:
         self._label = label
 
+    @property
+    def size(self) -> int:
+        """Number of bins, not counting any flow bins"""
+        raise NotImplementedError
+
     __hash__ = None  # type: ignore[assignment]  # mutable label, and __eq__ also accepts str
 
     def __eq__(self, other: object) -> bool:
@@ -166,7 +171,7 @@ class SparseAxis(Axis):
     SparseAxis: ABC for a sparse axis
 
     Derived should implement:
-        **index(identifier)** - return a hashable object for indexing
+        **index(identifier)** - return a bin index, or None to discard the fill
 
         **__eq__(axis)** - axis has same definition (not necessarily same bins)
 
@@ -177,7 +182,8 @@ class SparseAxis(Axis):
         **reduced(indices)** - return a new axis with only the given bins
     """
 
-    def index(self, identifier: Any) -> Any:
+    def index(self, identifier: Any) -> int | None:
+        """Bin index for an identifier; ``None`` means the fill is discarded"""
         raise NotImplementedError
 
     def _ireduce(self, the_slice: Any) -> list[int]:
@@ -187,14 +193,21 @@ class SparseAxis(Axis):
         raise NotImplementedError
 
     @property
-    def size(self) -> int:
-        """Number of bins, not counting the overflow bin"""
+    def extent(self) -> int:
+        """Number of bins, including the overflow bin if present"""
         raise NotImplementedError
 
     @property
     def overflow(self) -> bool:
         """Whether unmatched fills are counted in a trailing overflow bin"""
         raise NotImplementedError
+
+
+def _check_str(category: Any) -> None:
+    if not isinstance(category, str):
+        raise TypeError(
+            f"StrCategory only supports string categories, received {category!r}"
+        )
 
 
 class StrCategory(SparseAxis):
@@ -237,10 +250,7 @@ class StrCategory(SparseAxis):
             self._add(category)
 
     def _add(self, category: str) -> int:
-        if not isinstance(category, str):
-            raise TypeError(
-                f"StrCategory only supports string categories, received {category!r}"
-            )
+        _check_str(category)
         if category in self._indices:
             raise ValueError(f"Duplicate category {category!r}")
         index = len(self._indices)
@@ -248,7 +258,7 @@ class StrCategory(SparseAxis):
         return index
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({list(self._indices)})"
+        return f"{self.__class__.__name__}({self.identifiers()})"
 
     @property
     def growth(self) -> bool:
@@ -265,6 +275,11 @@ class StrCategory(SparseAxis):
         """Number of categories, not counting the overflow bin"""
         return len(self._indices)
 
+    @property
+    def extent(self) -> int:
+        """Number of categories, including the overflow bin if present"""
+        return self.size + 1 if self._overflow else self.size
+
     def index(self, identifier: str) -> int | None:
         """Index of a category
 
@@ -278,18 +293,16 @@ class StrCategory(SparseAxis):
         otherwise it maps to the overflow bin (index ``size``), or to
         ``None`` (meaning: discard) if ``overflow=False``.
         """
-        if not isinstance(identifier, str):
-            raise TypeError(
-                f"StrCategory only supports string categories, received {identifier!r}"
-            )
-        if identifier not in self._indices:
-            if self._growth:
-                return self._add(identifier)
-            return self.size if self._overflow else None
-        return self._indices[identifier]
+        _check_str(identifier)
+        idx = self._indices.get(identifier)
+        if idx is not None:
+            return idx
+        if self._growth:
+            return self._add(identifier)
+        return self.size if self._overflow else None
 
     def __getitem__(self, index: int) -> str:
-        return list(self._indices)[index]
+        return self.identifiers()[index]
 
     def _ireduce(self, the_slice: Any) -> list[int]:
         if isinstance(the_slice, str):
@@ -302,12 +315,8 @@ class StrCategory(SparseAxis):
                     f"Not all requested categories present in {self!r}", RuntimeWarning
                 )
             out = [k for k in the_slice if k in self._indices]
-        elif isinstance(the_slice, slice):
-            if the_slice != slice(None):
-                raise IndexError(
-                    f"Cannot understand slice {the_slice!r} on axis {self!r}"
-                )
-            out = list(self._indices)
+        elif the_slice == slice(None):
+            out = self.identifiers()
         else:
             raise IndexError(f"Cannot understand slice {the_slice!r} on axis {self!r}")
         return [self._indices[k] for k in out]
@@ -320,7 +329,7 @@ class StrCategory(SparseAxis):
             indices : list[int]
                 Category indices, usually as returned from ``StrCategory._ireduce``
         """
-        categories = list(self._indices)
+        categories = self.identifiers()
         return StrCategory(
             [categories[i] for i in indices],
             name=self._name,
@@ -357,11 +366,6 @@ class DenseAxis(Axis):
         raise NotImplementedError
 
     def reduced(self, islice: slice) -> DenseAxis:
-        raise NotImplementedError
-
-    @property
-    def size(self) -> int:
-        """Number of bins"""
         raise NotImplementedError
 
 

--- a/src/cuda_histogram/hist.py
+++ b/src/cuda_histogram/hist.py
@@ -196,6 +196,7 @@ class Hist:
         if self._sumw2 is not None:
             out._init_sumw2()
         sparse_axes = self.sparse_axes()
+        remaps = [{old: new for new, old in enumerate(idx)} for idx in sparse_idx]
 
         def remap_key(sparse_key: _SparseKey) -> _SparseKey | None:
             """Old sparse key -> reduced axes' bin indices, None to drop
@@ -204,11 +205,11 @@ class Hist:
             deselected categories are dropped, as in boost-histogram.
             """
             new_key = []
-            for k, idx, ax in zip(sparse_key, sparse_idx, sparse_axes, strict=True):
-                if k in idx:
-                    new_key.append(idx.index(k))
+            for k, remap, ax in zip(sparse_key, remaps, sparse_axes, strict=True):
+                if k in remap:
+                    new_key.append(remap[k])
                 elif ax.overflow and k == ax.size:
-                    new_key.append(len(idx))
+                    new_key.append(len(remap))
                 else:
                     return None
             return tuple(new_key)
@@ -237,8 +238,9 @@ class Hist:
         Parameters
         ----------
             *args : cupy.ndarray or str
-                Provide one value or array per dimension; a ``StrCategory``
-                axis takes a single string category.
+                Provide one CuPy array (0-d is fine) per dense axis and a
+                single string category per ``StrCategory`` axis; plain
+                Python numbers are not accepted.
             weight : cupy.ndarray
                 Provide weights.
         """

--- a/src/cuda_histogram/hist.py
+++ b/src/cuda_histogram/hist.py
@@ -9,10 +9,10 @@ import numpy as np
 
 from cuda_histogram.axis import (
     Axis,
-    # Cat,
     DenseAxis,
     Regular,
     SparseAxis,
+    StrCategory,
     Variable,
     _overflow_behavior,
 )
@@ -30,8 +30,8 @@ class _MaybeSumSlice(typing.NamedTuple):
     sum: bool
 
 
-# tuple of sparse-axis indices, empty while sparse axes are disabled
-_SparseKey = tuple[Any, ...]
+# tuple of sparse-axis bin indices, one entry per sparse axis
+_SparseKey = tuple[int, ...]
 
 
 def _assemble_blocks(array: Any, ndslice: list[Any], depth: int = 0) -> Any:
@@ -156,7 +156,7 @@ class Hist:
         if (
             not isinstance(keys, slice)
             and keys is not Ellipsis
-            and not isinstance(keys, int | float | tuple)
+            and not isinstance(keys, int | float | str | list | tuple)
         ):
             raise ValueError("use to_boost/to_hist to access other UHI functionalities")
         if not isinstance(keys, tuple):
@@ -176,8 +176,9 @@ class Hist:
         new_dims: list[Axis] = []
         for s, ax in zip(keys, self._axes, strict=False):
             if isinstance(ax, SparseAxis):
-                sparse_idx.append(ax._ireduce(s))
-                new_dims.append(ax)
+                indices = ax._ireduce(s)
+                sparse_idx.append(indices)
+                new_dims.append(ax.reduced(indices))
             else:
                 assert isinstance(ax, DenseAxis)
                 islice = ax._ireduce(s)
@@ -185,6 +186,8 @@ class Hist:
                 new_dims.append(ax.reduced(islice))
 
         def dense_op(array: Any) -> Any:
+            if not dense_idx:
+                return array
             as_numpy = array.get()
             blocked = np.block(_assemble_blocks(as_numpy, dense_idx))
             return cupy.asarray(blocked)
@@ -193,21 +196,23 @@ class Hist:
         if self._sumw2 is not None:
             out._init_sumw2()
         for sparse_key in self._sumw:
-            if not all(
-                k in idx for k, idx in zip(sparse_key, sparse_idx, strict=False)
-            ):
+            if not all(k in idx for k, idx in zip(sparse_key, sparse_idx, strict=True)):
                 continue
-            existing = sparse_key in out._sumw
+            # remap to the reduced axes' bin indices
+            new_key = tuple(
+                idx.index(k) for k, idx in zip(sparse_key, sparse_idx, strict=True)
+            )
+            existing = new_key in out._sumw
             if existing:
-                out._sumw[sparse_key] += dense_op(self._sumw[sparse_key])
+                out._sumw[new_key] += dense_op(self._sumw[sparse_key])
             else:
-                out._sumw[sparse_key] = dense_op(self._sumw[sparse_key]).copy()
+                out._sumw[new_key] = dense_op(self._sumw[sparse_key]).copy()
             if self._sumw2 is not None:
                 assert out._sumw2 is not None
                 if existing:
-                    out._sumw2[sparse_key] += dense_op(self._sumw2[sparse_key])
+                    out._sumw2[new_key] += dense_op(self._sumw2[sparse_key])
                 else:
-                    out._sumw2[sparse_key] = dense_op(self._sumw2[sparse_key]).copy()
+                    out._sumw2[new_key] = dense_op(self._sumw2[sparse_key]).copy()
         return out
 
     def fill(self, *args: Any, weight: Any = None) -> None:
@@ -216,8 +221,9 @@ class Hist:
 
         Parameters
         ----------
-            *args : cupy.ndarray
-                Provide one value or array per dimension.
+            *args : cupy.ndarray or str
+                Provide one value or array per dimension; a ``StrCategory``
+                axis takes a single string category.
             weight : cupy.ndarray
                 Provide weights.
         """
@@ -289,28 +295,35 @@ class Hist:
         else:
             return arr[tuple(_overflow_behavior(flow) for _ in range(self.dense_dim()))]
 
+    def _stack_sparse(self, sumw: dict[_SparseKey, Any], flow: bool) -> Any:
+        """Stack per-sparse-key storage into one array, axes in histogram order
+
+        Sparse-axis bins that were never filled are zero.
+        """
+        dense_shape = (
+            self._dense_shape if flow else tuple(n - 3 for n in self._dense_shape)
+        )
+        sparse_shape = tuple(ax.size for ax in self.sparse_axes())
+        out = cupy.zeros(shape=sparse_shape + dense_shape, dtype=self._dtype)
+        for key, array in sumw.items():
+            out[key] = self._view_dim(array, flow)
+        order = [i for i, ax in enumerate(self._axes) if isinstance(ax, SparseAxis)]
+        order += [i for i, ax in enumerate(self._axes) if isinstance(ax, DenseAxis)]
+        return cupy.moveaxis(out, tuple(range(len(order))), tuple(order))
+
     def values(self, flow: bool = False) -> Any:
         """Extract the values from this histogram.
+
+        Sparse (categorical) axes appear as ordinary dimensions of the
+        returned array, with categories in axis order; ``flow`` only affects
+        dense axes.
 
         Parameters
         ----------
         flow : bool
         """
-
-        # TODO: cleanup logic for sparse axis
-        # out = {}
-        # for sparse_key in self._sumw:
-        #     id_key = tuple(ax[k] for ax, k in zip(self.sparse_axes(), sparse_key))
-        #     if sumw2:
-        #         if self._sumw2 is not None:
-        #             w2 = self._view_dim(self._sumw2[sparse_key])
-        #         else:
-        #             w2 = self._view_dim(self._sumw[sparse_key])
-        #         out[id_key] = (self._view_dim(self._sumw[sparse_key]), w2)
-        #     else:
-        #         out[id_key] = self._view_dim(self._sumw[sparse_key])
-        # return out
-
+        if self.sparse_axes():
+            return self._stack_sparse(self._sumw, flow)
         return (
             self._view_dim(cupy.zeros(shape=self._dense_shape), flow)
             if not self._sumw
@@ -320,48 +333,25 @@ class Hist:
     def variance(self, flow: bool = False) -> Any:
         """Extract the variances from this histogram.
 
+        ``None`` if no weighted fills have happened; otherwise shaped like
+        ``values(flow)``.
+
         Parameters
         ----------
         flow : bool
         """
-        return (
-            None
-            if self._sumw2 is None
-            else self._view_dim(next(iter(self._sumw2.values())), flow)
-        )
-
-    # TODO: cleanup logic for sparse axis
-    # def identifiers(self, axis, overflow="none"):
-    #     """Return a list of identifiers for an axis
-
-    #     Parameters
-    #     ----------
-    #         axis
-    #             Axis object
-    #         overflow
-    #             See `sum` description for meaning of allowed values
-    #     """
-    #     if isinstance(axis, SparseAxis):
-    #         out = []
-    #         isparse = self._isparse(axis)
-    #         for identifier in axis.identifiers():
-    #             if any(k[isparse] == axis.index(identifier) for k in self._sumw):
-    #                 out.append(identifier)
-    #         if axis.sorting == "integral":
-    #             hproj = {
-    #                 key[0]: integral
-    #                 for key, integral in self.project(axis).values().items()
-    #             }
-    #             out.sort(key=lambda k: hproj[k.name])
-    #         return out
-    #     elif isinstance(axis, DenseAxis):
-    #         return axis.identifiers(overflow=overflow)
+        if self._sumw2 is None:
+            return None
+        if self.sparse_axes():
+            return self._stack_sparse(self._sumw2, flow)
+        return self._view_dim(next(iter(self._sumw2.values())), flow)
 
     def to_boost(self) -> boost_histogram.Histogram[Any]:
         """
         Convert this cuda_histogram object to a boost_histogram object.
 
         underflow and overflow are set True and nanflow is lost in the conversion.
+        Categorical axes convert to growable ``StrCategory`` axes.
 
         Appropriate boost-histogram axis and storage are automatically chosen.
         All the arguments of cuda-histogram's axis and histogram are passed down.
@@ -370,7 +360,9 @@ class Hist:
         import hist  # noqa: PLC0415
 
         # hist's axes subclass boost-histogram's and carry name/label properly
-        newaxes: list[hist.axis.Regular | hist.axis.Variable] = []
+        newaxes: list[
+            hist.axis.Regular | hist.axis.Variable | hist.axis.StrCategory
+        ] = []
         for axis in self.axes():
             if isinstance(axis, Regular):
                 newaxes.append(
@@ -394,17 +386,16 @@ class Hist:
                         label=axis.label,
                     )
                 )
-            # TODO: cleanup logic for sparse axis
-            # elif isinstance(axis, Cat):
-            #     identifiers = self.identifiers(axis)
-            #     newaxis = boost_histogram.axis.StrCategory(
-            #         [x.name for x in identifiers],
-            #         growth=True,
-            #     )
-            #     newaxis.name = axis.name
-            #     newaxis.label = axis.label
-            #     newaxis.bin_labels = [x.label for x in identifiers]
-            #     newaxes.append(newaxis)
+            elif isinstance(axis, StrCategory):
+                # growth=True so the axis has no overflow slot
+                newaxes.append(
+                    hist.axis.StrCategory(
+                        axis.identifiers(),
+                        growth=True,
+                        name=axis.name,
+                        label=axis.label,
+                    )
+                )
 
         storage: boost_histogram.storage.Storage
         if self._sumw2 is None:
@@ -416,40 +407,21 @@ class Hist:
         out.label = self.label  # type: ignore[attr-defined]
 
         view = out.view(flow=True)
-        nonan = [slice(None, -1, None)] * (len(newaxes))
+        # drop the nanflow bin of dense axes; category axes have no flow bins
+        nonan = tuple(
+            slice(None) if isinstance(axis, SparseAxis) else slice(None, -1)
+            for axis in self.axes()
+        )
         if self._sumw2 is None:
-            view[:] = self.values(flow=True)[(*nonan,)].get()
+            view[:] = self.values(flow=True)[nonan].get()
         else:
             view[:] = cupy.stack(
                 (
-                    self.values(flow=True)[(*nonan,)],
-                    self.variance(flow=True)[(*nonan,)],
+                    self.values(flow=True)[nonan],
+                    self.variance(flow=True)[nonan],
                 ),
                 axis=len(newaxes),
             ).get()
-
-        # TODO: cleanup logic for sparse axis
-        # def expandkey(key):
-        #     kiter = iter(key)
-        #     for ax in newaxes:
-        #         if isinstance(ax, boost_histogram.axis.StrCategory):
-        #             yield ax.index(next(kiter))
-        #         else:
-        #             yield slice(None)
-
-        # if self._sumw2 is None:
-        #     values = self.values(overflow="all")
-        #     for sparse_key, sumw in values.items():
-        #         index = tuple(expandkey(sparse_key))
-        #         view = out.view(flow=True)
-        #         view[index] = sumw.get()
-        # else:
-        #     values = self.values(sumw2=True, overflow="all")
-        #     for sparse_key, (sumw, sumw2) in values.items():
-        #         index = tuple(expandkey(sparse_key))
-        #         view = out.view(flow=True)
-        #         view[index].value = sumw.get()
-        #         view[index].variance = sumw2.get()
 
         return out
 

--- a/src/cuda_histogram/hist.py
+++ b/src/cuda_histogram/hist.py
@@ -195,13 +195,28 @@ class Hist:
         out = Hist(*new_dims, label=self._label)
         if self._sumw2 is not None:
             out._init_sumw2()
+        sparse_axes = self.sparse_axes()
+
+        def remap_key(sparse_key: _SparseKey) -> _SparseKey | None:
+            """Old sparse key -> reduced axes' bin indices, None to drop
+
+            Overflow content stays in the reduced axis's overflow bin;
+            deselected categories are dropped, as in boost-histogram.
+            """
+            new_key = []
+            for k, idx, ax in zip(sparse_key, sparse_idx, sparse_axes, strict=True):
+                if k in idx:
+                    new_key.append(idx.index(k))
+                elif ax.overflow and k == ax.size:
+                    new_key.append(len(idx))
+                else:
+                    return None
+            return tuple(new_key)
+
         for sparse_key in self._sumw:
-            if not all(k in idx for k, idx in zip(sparse_key, sparse_idx, strict=True)):
+            new_key = remap_key(sparse_key)
+            if new_key is None:
                 continue
-            # remap to the reduced axes' bin indices
-            new_key = tuple(
-                idx.index(k) for k, idx in zip(sparse_key, sparse_idx, strict=True)
-            )
             existing = new_key in out._sumw
             if existing:
                 out._sumw[new_key] += dense_op(self._sumw[sparse_key])
@@ -235,14 +250,17 @@ class Hist:
         if len(self._axes) != len(args):
             raise ValueError("mismatching dimensions for provided values and axes")
 
-        if weight is not None and self._sumw2 is None:
-            self._init_sumw2()
-
         sparse_key = tuple(
             d.index(value)
             for d, value in zip(self._axes, args, strict=False)
             if isinstance(d, SparseAxis)
         )
+        # an unknown category on an overflow=False axis discards the fill
+        if any(k is None for k in sparse_key):
+            return
+
+        if weight is not None and self._sumw2 is None:
+            self._init_sumw2()
 
         if sparse_key not in self._sumw:
             self._sumw[sparse_key] = cupy.zeros(
@@ -298,14 +316,21 @@ class Hist:
     def _stack_sparse(self, sumw: dict[_SparseKey, Any], flow: bool) -> Any:
         """Stack per-sparse-key storage into one array, axes in histogram order
 
-        Sparse-axis bins that were never filled are zero.
+        Sparse-axis bins that were never filled are zero. With ``flow``, an
+        axis with ``overflow=True`` gets a trailing overflow bin.
         """
         dense_shape = (
             self._dense_shape if flow else tuple(n - 3 for n in self._dense_shape)
         )
-        sparse_shape = tuple(ax.size for ax in self.sparse_axes())
+        sparse_shape = tuple(
+            ax.size + 1 if flow and ax.overflow else ax.size
+            for ax in self.sparse_axes()
+        )
         out = cupy.zeros(shape=sparse_shape + dense_shape, dtype=self._dtype)
         for key, array in sumw.items():
+            # without flow, this drops content in category overflow bins
+            if any(k >= n for k, n in zip(key, sparse_shape, strict=True)):
+                continue
             out[key] = self._view_dim(array, flow)
         order = [i for i, ax in enumerate(self._axes) if isinstance(ax, SparseAxis)]
         order += [i for i, ax in enumerate(self._axes) if isinstance(ax, DenseAxis)]
@@ -315,8 +340,9 @@ class Hist:
         """Extract the values from this histogram.
 
         Sparse (categorical) axes appear as ordinary dimensions of the
-        returned array, with categories in axis order; ``flow`` only affects
-        dense axes.
+        returned array, with categories in axis order; with ``flow``, a
+        categorical axis contributes a trailing overflow bin only if it has
+        ``overflow=True``.
 
         Parameters
         ----------
@@ -351,7 +377,8 @@ class Hist:
         Convert this cuda_histogram object to a boost_histogram object.
 
         underflow and overflow are set True and nanflow is lost in the conversion.
-        Categorical axes convert to growable ``StrCategory`` axes.
+        Categorical axes convert to ``StrCategory`` axes with the same
+        ``growth``/``overflow`` settings.
 
         Appropriate boost-histogram axis and storage are automatically chosen.
         All the arguments of cuda-histogram's axis and histogram are passed down.
@@ -387,11 +414,11 @@ class Hist:
                     )
                 )
             elif isinstance(axis, StrCategory):
-                # growth=True so the axis has no overflow slot
                 newaxes.append(
                     hist.axis.StrCategory(
                         axis.identifiers(),
-                        growth=True,
+                        growth=axis.growth,
+                        overflow=axis.overflow,
                         name=axis.name,
                         label=axis.label,
                     )
@@ -407,7 +434,8 @@ class Hist:
         out.label = self.label  # type: ignore[attr-defined]
 
         view = out.view(flow=True)
-        # drop the nanflow bin of dense axes; category axes have no flow bins
+        # drop the nanflow bin of dense axes; a category axis has no nanflow,
+        # and values(flow=True) already matches its extent
         nonan = tuple(
             slice(None) if isinstance(axis, SparseAxis) else slice(None, -1)
             for axis in self.axes()

--- a/src/cuda_histogram/hist.py
+++ b/src/cuda_histogram/hist.py
@@ -140,9 +140,6 @@ class Hist:
         """All sparse axes"""
         return [ax for ax in self._axes if isinstance(ax, SparseAxis)]
 
-    def _isparse(self, axis: SparseAxis) -> int:
-        return self.sparse_axes().index(axis)
-
     def _init_sumw2(self) -> None:
         self._sumw2 = {key: value.copy() for key, value in self._sumw.items()}
 
@@ -186,8 +183,9 @@ class Hist:
                 new_dims.append(ax.reduced(islice))
 
         def dense_op(array: Any) -> Any:
+            """Apply the dense slices, always returning a fresh array"""
             if not dense_idx:
-                return array
+                return array.copy()
             as_numpy = array.get()
             blocked = np.block(_assemble_blocks(as_numpy, dense_idx))
             return cupy.asarray(blocked)
@@ -222,13 +220,13 @@ class Hist:
             if existing:
                 out._sumw[new_key] += dense_op(self._sumw[sparse_key])
             else:
-                out._sumw[new_key] = dense_op(self._sumw[sparse_key]).copy()
+                out._sumw[new_key] = dense_op(self._sumw[sparse_key])
             if self._sumw2 is not None:
                 assert out._sumw2 is not None
                 if existing:
                     out._sumw2[new_key] += dense_op(self._sumw2[sparse_key])
                 else:
-                    out._sumw2[new_key] = dense_op(self._sumw2[sparse_key]).copy()
+                    out._sumw2[new_key] = dense_op(self._sumw2[sparse_key])
         return out
 
     def fill(self, *args: Any, weight: Any = None) -> None:
@@ -245,21 +243,22 @@ class Hist:
                 Provide weights.
         """
         if not all(isinstance(a, cupy.ndarray | str) for a in args):
-            raise TypeError("pass CuPy arrays")
+            raise TypeError("pass CuPy arrays (or a string per StrCategory axis)")
         if weight is not None and not isinstance(weight, cupy.ndarray):
             raise TypeError("pass CuPy arrays")
 
         if len(self._axes) != len(args):
             raise ValueError("mismatching dimensions for provided values and axes")
 
-        sparse_key = tuple(
+        indices = tuple(
             d.index(value)
             for d, value in zip(self._axes, args, strict=False)
             if isinstance(d, SparseAxis)
         )
         # an unknown category on an overflow=False axis discards the fill
-        if any(k is None for k in sparse_key):
+        if any(k is None for k in indices):
             return
+        sparse_key = typing.cast("_SparseKey", indices)
 
         if weight is not None and self._sumw2 is None:
             self._init_sumw2()
@@ -325,8 +324,7 @@ class Hist:
             self._dense_shape if flow else tuple(n - 3 for n in self._dense_shape)
         )
         sparse_shape = tuple(
-            ax.size + 1 if flow and ax.overflow else ax.size
-            for ax in self.sparse_axes()
+            ax.extent if flow else ax.size for ax in self.sparse_axes()
         )
         out = cupy.zeros(shape=sparse_shape + dense_shape, dtype=self._dtype)
         for key, array in sumw.items():
@@ -350,13 +348,9 @@ class Hist:
         ----------
         flow : bool
         """
-        if self.sparse_axes():
+        if self.sparse_axes() or not self._sumw:
             return self._stack_sparse(self._sumw, flow)
-        return (
-            self._view_dim(cupy.zeros(shape=self._dense_shape), flow)
-            if not self._sumw
-            else self._view_dim(next(iter(self._sumw.values())), flow)
-        )
+        return self._view_dim(next(iter(self._sumw.values())), flow)
 
     def variance(self, flow: bool = False) -> Any:
         """Extract the variances from this histogram.
@@ -370,7 +364,7 @@ class Hist:
         """
         if self._sumw2 is None:
             return None
-        if self.sparse_axes():
+        if self.sparse_axes() or not self._sumw2:
             return self._stack_sparse(self._sumw2, flow)
         return self._view_dim(next(iter(self._sumw2.values())), flow)
 

--- a/tests/test_hist_tools.py
+++ b/tests/test_hist_tools.py
@@ -281,15 +281,20 @@ def test_str_category_axis() -> None:
     assert ax[-1] == "two"
     assert ax.identifiers() == ["one", "two"]
     assert repr(ax) == "StrCategory(['one', 'two'])"
-    with pytest.raises(KeyError):
-        ax.index("three")
+    assert ax.overflow
+    assert ax.index("three") == 2  # overflow bin
     assert ax.size == 2
     with pytest.raises(TypeError):
         ax.index(1)  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="Duplicate"):
         cuda_histogram.axis.StrCategory(["a", "a"])
 
+    no_overflow = cuda_histogram.axis.StrCategory(["one", "two"], overflow=False)
+    assert not no_overflow.overflow
+    assert no_overflow.index("three") is None
+
     grow = cuda_histogram.axis.StrCategory(growth=True)
+    assert not grow.overflow  # a growing axis matches everything
     assert grow.size == 0
     assert grow.index("b") == 0
     assert grow.index("a") == 1
@@ -319,16 +324,29 @@ def test_str_category_fill() -> None:
     assert (h.values() == cp.array([[1, 2, 0, 0], [0, 0, 3, 0]])).all()
     assert (h.variance() == cp.array([[1, 2, 0, 0], [0, 0, 5, 0]])).all()
 
-    # unknown category on a non-growing axis
+    # unknown category on a non-growing axis lands in the overflow bin
     fixed = cuda_histogram.Hist(
         cuda_histogram.axis.StrCategory(["a", "b"], name="sample"),
         cuda_histogram.axis.Regular(4, 0, 1, name="x"),
     )
     assert fixed.values().shape == (2, 4)
+    assert fixed.values(flow=True).shape == (3, 7)
     fixed.fill("b", cp.array([0.1]))
+    fixed.fill("c", cp.array([0.1]))
     assert (fixed.values() == cp.array([[0, 0, 0, 0], [1, 0, 0, 0]])).all()
-    with pytest.raises(KeyError):
-        fixed.fill("c", cp.array([0.1]))
+    assert (fixed.values(flow=True)[2] == cp.array([0, 1, 0, 0, 0, 0, 0])).all()
+
+    # with overflow off, unknown categories are discarded
+    discard = cuda_histogram.Hist(
+        cuda_histogram.axis.StrCategory(["a", "b"], overflow=False, name="sample"),
+        cuda_histogram.axis.Regular(4, 0, 1, name="x"),
+    )
+    assert discard.values(flow=True).shape == (2, 7)
+    discard.fill("c", cp.array([0.1]), weight=cp.array([2.0]))
+    assert discard.values(flow=True).sum() == 0
+    assert discard.variance() is None  # the discarded fill never seeded sumw2
+    discard.fill("a", cp.array([0.1]))
+    assert (discard.values() == cp.array([[1, 0, 0, 0], [0, 0, 0, 0]])).all()
 
 
 def test_str_category_only() -> None:
@@ -376,6 +394,41 @@ def test_str_category_getitem() -> None:
     assert empty.values().shape == (0, 4)
     with pytest.raises(IndexError):
         h[0.5, :]
+
+
+def test_str_category_overflow_slicing_and_convert() -> None:
+    h = cuda_histogram.Hist(
+        cuda_histogram.axis.StrCategory(["a", "b"], name="s"),
+        cuda_histogram.axis.Regular(4, 0, 1, name="x"),
+    )
+    h.fill("a", cp.array([0.1, 0.3]))
+    h.fill("b", cp.array([0.5]))
+    h.fill("zzz", cp.array([0.7, 0.7, 0.7]))
+    assert h.values().sum() == 3
+    assert h.values(flow=True).sum() == 6
+
+    # overflow content survives selection, like boost-histogram picks
+    pick = h["b"]
+    assert pick.values(flow=True).shape == (2, 7)
+    assert (pick.values(flow=True)[1] == h.values(flow=True)[2]).all()
+    assert pick.values(flow=True)[1].sum() == 3
+
+    out = h.to_boost()
+    assert not out.axes[0].traits.growth
+    assert out.axes[0].traits.overflow
+    assert out.axes[0].extent == 3
+    assert (out.values() == h.values().get()).all()
+    # the overflow bin round-trips (drop only the dense nanflow on our side)
+    assert (out.view(flow=True) == h.values(flow=True)[:, :-1].get()).all()
+
+    no_overflow = cuda_histogram.Hist(
+        cuda_histogram.axis.StrCategory(["a", "b"], overflow=False, name="s"),
+    )
+    no_overflow.fill("a")
+    out2 = no_overflow.to_boost()
+    assert not out2.axes[0].traits.overflow
+    assert out2.axes[0].extent == 2
+    assert (out2.values() == no_overflow.values().get()).all()
 
 
 def test_str_category_axis_order() -> None:

--- a/tests/test_hist_tools.py
+++ b/tests/test_hist_tools.py
@@ -133,7 +133,8 @@ def test_partial_indexing() -> None:
         h[0.1, 3, 5]
     with pytest.raises(IndexError):
         h[..., ...]
-    with pytest.raises(ValueError):
+    # strings are category selections, meaningless on a dense axis
+    with pytest.raises(IndexError):
         h["x"]
 
 
@@ -260,6 +261,167 @@ def test_cpu_conversion() -> None:
     assert h.values().shape == dummy.values().shape
     assert h[bh.underflow, bh.underflow].variance == 4.0  # type: ignore[union-attr]
     assert h.storage_type == bh.storage.Weight
+
+
+def _cat_axis(h: cuda_histogram.Hist, i: int = 0) -> cuda_histogram.axis.StrCategory:
+    ax = h.axes()[i]
+    assert isinstance(ax, cuda_histogram.axis.StrCategory)
+    return ax
+
+
+def test_str_category_axis() -> None:
+    ax = cuda_histogram.axis.StrCategory(["one", "two"], name="s", label="sample")
+    assert ax.size == 2
+    assert ax.name == "s"
+    assert ax.label == "sample"
+    assert not ax.growth
+    assert ax.index("one") == 0
+    assert ax.index("two") == 1
+    assert ax[0] == "one"
+    assert ax[-1] == "two"
+    assert ax.identifiers() == ["one", "two"]
+    assert repr(ax) == "StrCategory(['one', 'two'])"
+    with pytest.raises(KeyError):
+        ax.index("three")
+    assert ax.size == 2
+    with pytest.raises(TypeError):
+        ax.index(1)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="Duplicate"):
+        cuda_histogram.axis.StrCategory(["a", "a"])
+
+    grow = cuda_histogram.axis.StrCategory(growth=True)
+    assert grow.size == 0
+    assert grow.index("b") == 0
+    assert grow.index("a") == 1
+    assert grow.index("b") == 0
+    assert grow.identifiers() == ["b", "a"]
+
+
+def test_str_category_fill() -> None:
+    h = cuda_histogram.Hist(
+        cuda_histogram.axis.StrCategory(growth=True, name="sample"),
+        cuda_histogram.axis.Regular(4, 0, 1, name="x"),
+    )
+    assert h.values().shape == (0, 4)
+    assert h.dense_dim() == 1
+    assert h.sparse_axes() == [h.axes()[0]]
+
+    h.fill("ttbar", cp.array([0.1, 0.3, 0.3]))
+    h.fill("qcd", cp.array([0.6]))
+    assert h.values().shape == (2, 4)
+    assert (h.values() == cp.array([[1, 2, 0, 0], [0, 0, 1, 0]])).all()
+    assert h.values(flow=True).shape == (2, 7)
+    assert (h.values(flow=True).sum(axis=1) == cp.array([3, 1])).all()
+    assert h.variance() is None
+
+    h.fill("qcd", cp.array([0.6]), weight=cp.array([2.0]))
+    assert h.variance() is not None
+    assert (h.values() == cp.array([[1, 2, 0, 0], [0, 0, 3, 0]])).all()
+    assert (h.variance() == cp.array([[1, 2, 0, 0], [0, 0, 5, 0]])).all()
+
+    # unknown category on a non-growing axis
+    fixed = cuda_histogram.Hist(
+        cuda_histogram.axis.StrCategory(["a", "b"], name="sample"),
+        cuda_histogram.axis.Regular(4, 0, 1, name="x"),
+    )
+    assert fixed.values().shape == (2, 4)
+    fixed.fill("b", cp.array([0.1]))
+    assert (fixed.values() == cp.array([[0, 0, 0, 0], [1, 0, 0, 0]])).all()
+    with pytest.raises(KeyError):
+        fixed.fill("c", cp.array([0.1]))
+
+
+def test_str_category_only() -> None:
+    h = cuda_histogram.Hist(cuda_histogram.axis.StrCategory(growth=True, name="s"))
+    h.fill("a")
+    h.fill("a")
+    h.fill("b", weight=cp.array([3.0]))
+    assert (h.values() == cp.array([2.0, 3.0])).all()
+    assert (h.variance() == cp.array([2.0, 9.0])).all()
+
+    sel = h["b"]
+    assert _cat_axis(sel).identifiers() == ["b"]
+    assert (sel.values() == cp.array([3.0])).all()
+
+
+def test_str_category_getitem() -> None:
+    h = cuda_histogram.Hist(
+        cuda_histogram.axis.StrCategory(growth=True, name="sample"),
+        cuda_histogram.axis.Regular(4, 0, 1, name="x"),
+    )
+    h.fill("ttbar", cp.array([0.1, 0.3, 0.3]))
+    h.fill("qcd", cp.array([0.6]), weight=cp.array([2.0]))
+    h.fill("zjets", cp.array([0.9, 0.9]))
+
+    sel = h["qcd"]
+    assert isinstance(sel, cuda_histogram.Hist)
+    assert _cat_axis(sel).identifiers() == ["qcd"]
+    assert sel.values().shape == (1, 4)
+    assert (sel.values()[0] == h.values()[1]).all()
+    assert (sel.variance()[0] == h.variance()[1]).all()
+
+    # list selection keeps the requested order
+    sub = h[["zjets", "ttbar"], :]
+    assert _cat_axis(sub).identifiers() == ["zjets", "ttbar"]
+    assert (sub.values() == cp.stack([h.values()[2], h.values()[0]])).all()
+
+    # a full slice keeps everything; dense slicing works alongside
+    assert (h[:, :].values() == h.values()).all()
+    assert (h["ttbar", 0.3].values()[0, 0] == h.values()[0, 1]).all()
+
+    with pytest.raises(KeyError):
+        h["nope"]
+    with pytest.warns(RuntimeWarning):
+        empty = h[["nope"], :]
+    assert empty.values().shape == (0, 4)
+    with pytest.raises(IndexError):
+        h[0.5, :]
+
+
+def test_str_category_axis_order() -> None:
+    h = cuda_histogram.Hist(
+        cuda_histogram.axis.Regular(3, 0, 1, name="x"),
+        cuda_histogram.axis.StrCategory(growth=True, name="s"),
+    )
+    h.fill(cp.array([0.1, 0.5]), "a")
+    h.fill(cp.array([0.9]), "b")
+    assert h.values().shape == (3, 2)
+    assert (h.values()[:, 0] == cp.array([1, 1, 0])).all()
+    assert (h.values()[:, 1] == cp.array([0, 0, 1])).all()
+
+    out = h.to_boost()
+    assert (out.values() == h.values().get()).all()
+
+
+def test_str_category_to_boost() -> None:
+    import boost_histogram as bh
+
+    h = cuda_histogram.Hist(
+        cuda_histogram.axis.StrCategory(growth=True, name="dataset", label="Sample"),
+        cuda_histogram.axis.Regular(3, 0, 1, name="x"),
+        label="events",
+    )
+    h.fill("ttbar", cp.array([0.1, 0.5, 1.5]))
+    h.fill("qcd", cp.array([-0.5, 0.9]))
+
+    out = h.to_boost()
+    assert isinstance(out.axes[0], bh.axis.StrCategory)
+    assert list(out.axes[0]) == ["ttbar", "qcd"]
+    assert out.axes[0].name == "dataset"
+    assert out.axes[0].label == "Sample"
+    assert out.storage_type == bh.storage.Double
+    assert (out.values() == h.values().get()).all()
+    assert out[bh.loc("ttbar"), bh.overflow] == 1.0
+    assert out[bh.loc("qcd"), bh.underflow] == 1.0
+
+    h.fill("qcd", cp.array([0.9]), weight=cp.array([2.0]))
+    out = h.to_boost()
+    assert out.storage_type == bh.storage.Weight
+    assert (out.values() == h.values().get()).all()
+    assert (out.variances() == h.variance().get()).all()
+
+    hh = h.to_hist()
+    assert (hh.values() == h.values().get()).all()
 
 
 def test_hist_conversion() -> None:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Closes #23.

Replaces the commented-out coffea-era `Cat`/`StringBin` sparse axes with a `StrCategory` axis modeled on `boost_histogram.axis.StrCategory`: categories in insertion order, boost-histogram's `growth` and `overflow` behaviors, and sparse storage (only filled categories occupy memory).

- `Hist.fill()` takes a plain string per `StrCategory` axis. Unknown categories grow the axis (`growth=True`), land in a trailing overflow bin (`overflow=True`, the default), or are discarded (`overflow=False`) — same semantics as boost-histogram.
- `values()`/`variance()` stack the sparse storage into a dense CuPy array with category dimensions in axis order; `flow=True` includes the category overflow bin when the axis has one.
- `Hist.__getitem__` accepts a category string or a list of categories (list selection keeps the requested order); overflow content survives selection unchanged, matching boost-histogram picks. A string on a dense axis now raises `IndexError` instead of `ValueError`.
- `to_boost()`/`to_hist()` convert to `hist.axis.StrCategory` preserving `name`/`label` and the `growth`/`overflow` settings, with the overflow bin round-tripping.

Full test suite run locally on a GPU (CI has none).