### PR TITLE
feat: add an Integer dense axis

### DIFF
--- a/src/cuda_histogram/axis/__init__.py
+++ b/src/cuda_histogram/axis/__init__.py
@@ -12,6 +12,7 @@ import numpy as np
 
 __all__: list[str] = [
     "Bin",
+    "Integer",
     "Interval",
     "Regular",
     "StrCategory",
@@ -710,6 +711,63 @@ class Regular(Bin):
             ihi = islice.stop - 1
         bins = ihi - ilo
         return Regular(bins, lo, hi, name=self._name, label=self._label)
+
+
+class Integer(Regular):
+    """
+    Make an axis with unit-width integer bins from start (inclusive)
+    to stop (exclusive), modeled on ``boost_histogram.axis.Integer``.
+
+    Parameters
+    ----------
+        start : int
+            The first bin value, inclusive.
+        stop : int
+            One past the last bin value (there are ``stop - start`` bins).
+        name : str
+            Axis name.
+        label : str
+            Axis label.
+
+    Float fills bin by floor: any value in ``[v, v + 1)`` lands in the
+    bin for integer ``v``.
+    """
+
+    def __init__(
+        self,
+        start: int,
+        stop: int,
+        *,
+        name: str = "",
+        label: str = "",
+    ) -> None:
+        start = int(start)
+        stop = int(stop)
+        if stop <= start:
+            raise ValueError(f"stop ({stop}) must be greater than start ({start})")
+        super().__init__(stop - start, start, stop, name=name, label=label)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self._lo}, {self._hi})"
+
+    def reduced(self, islice: slice) -> Integer:
+        """
+        Return a new axis with reduced binning
+        The new binning corresponds to the slice made on this axis.
+        Overflow will be taken care of by ``Hist.__getitem__``
+
+        Parameters
+        ----------
+            islice : slice
+                ``islice.start`` and ``islice.stop`` should be None or within ``[1, ax.size() - 1]``
+                This slice is usually as returned from ``Bin._ireduce``
+        """
+        reduced = super().reduced(islice)
+        if reduced is self:
+            return self
+        return Integer(
+            int(reduced._lo), int(reduced._hi), name=self._name, label=self._label
+        )
 
 
 class Variable(Bin):

--- a/src/cuda_histogram/hist.py
+++ b/src/cuda_histogram/hist.py
@@ -10,6 +10,7 @@ import numpy as np
 from cuda_histogram.axis import (
     Axis,
     DenseAxis,
+    Integer,
     Regular,
     SparseAxis,
     StrCategory,
@@ -384,10 +385,25 @@ class Hist:
 
         # hist's axes subclass boost-histogram's and carry name/label properly
         newaxes: list[
-            hist.axis.Regular | hist.axis.Variable | hist.axis.StrCategory
+            hist.axis.Regular
+            | hist.axis.Integer
+            | hist.axis.Variable
+            | hist.axis.StrCategory
         ] = []
         for axis in self.axes():
-            if isinstance(axis, Regular):
+            # Integer subclasses Regular, so it must be checked first
+            if isinstance(axis, Integer):
+                newaxes.append(
+                    hist.axis.Integer(
+                        axis._lo,
+                        axis._hi,
+                        underflow=True,
+                        overflow=True,
+                        name=axis.name,
+                        label=axis.label,
+                    )
+                )
+            elif isinstance(axis, Regular):
                 newaxes.append(
                     hist.axis.Regular(
                         axis._bins,

--- a/tests/test_integer_axis.py
+++ b/tests/test_integer_axis.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+cp = pytest.importorskip("cupy")
+
+import cuda_histogram
+
+# cupy might be installable on a device with no GPUs
+try:
+    cp.cuda.runtime.getDeviceCount()
+except cp.cuda.runtime.CUDARuntimeError:
+    pytest.skip("CUDA not found", allow_module_level=True)
+
+
+def test_integer_axis() -> None:
+    ax = cuda_histogram.axis.Integer(-2, 3, name="n", label="count")
+    assert ax.size == 5
+    assert ax.name == "n"
+    assert ax.label == "count"
+    assert repr(ax) == "Integer(-2, 3)"
+    assert (ax.edges() == cp.array([-2.0, -1.0, 0.0, 1.0, 2.0, 3.0])).all()
+    with pytest.raises(ValueError, match="greater than"):
+        cuda_histogram.axis.Integer(2, 2)
+
+
+def test_integer_fill_and_values() -> None:
+    h = cuda_histogram.Hist(cuda_histogram.axis.Integer(-2, 3, name="n"))
+    assert h.values().shape == (5,)
+    assert h.values(flow=True).shape == (8,)
+
+    h.fill(cp.array([-2, 0, 0, 2, 2, 2]))
+    assert (h.values() == cp.array([1.0, 0.0, 2.0, 0.0, 3.0])).all()
+
+    # floats bin by floor: value v lands in bin v - start
+    h.fill(cp.array([0.5, 2.999, -1.0]))
+    assert (h.values() == cp.array([1.0, 1.0, 3.0, 0.0, 4.0])).all()
+
+
+def test_integer_flow_bins() -> None:
+    h = cuda_histogram.Hist(cuda_histogram.axis.Integer(0, 4, name="n"))
+    h.fill(cp.array([-1.0, -100.0, 4.0, 17.0, np.nan, np.nan, np.nan, 1.0]))
+    flow = h.values(flow=True)
+    assert flow[0] == 2.0  # underflow
+    assert flow[-2] == 2.0  # overflow
+    assert flow[-1] == 3.0  # nanflow
+    assert (h.values() == cp.array([0.0, 1.0, 0.0, 0.0])).all()
+
+
+def test_integer_slicing() -> None:
+    h = cuda_histogram.Hist(cuda_histogram.axis.Integer(-2, 3, name="n"))
+    h.fill(cp.array([-2, -1, 0, 0, 1, 2, 2, 5, -7]))
+
+    sliced = h[0:2]
+    (ax,) = sliced.axes()
+    assert isinstance(ax, cuda_histogram.axis.Integer)
+    assert ax.size == 2
+    assert repr(ax) == "Integer(0, 2)"
+    assert (sliced.values() == cp.array([2.0, 1.0])).all()
+    # out-of-slice content is summed into the flow bins
+    assert sliced.values(flow=True)[0] == 3.0
+    assert sliced.values(flow=True)[-2] == 3.0
+
+    single = h[0]
+    (ax,) = single.axes()
+    assert isinstance(ax, cuda_histogram.axis.Integer)
+    assert ax.size == 1
+    assert (single.values() == cp.array([2.0])).all()
+
+    assert h[:].axes() == h.axes()
+    assert (h[:].values(flow=True) == h.values(flow=True)).all()
+
+
+def test_integer_to_hist_roundtrip() -> None:
+    hist = pytest.importorskip("hist")
+
+    h = cuda_histogram.Hist(cuda_histogram.axis.Integer(-2, 3, name="n", label="count"))
+    h.fill(cp.array([-5.0, -2.0, 0.0, 0.0, 2.0, 9.0, np.nan]))
+
+    converted = h.to_hist()
+    (ax,) = converted.axes
+    assert isinstance(ax, hist.axis.Integer)
+    assert ax.name == "n"
+    assert ax.label == "count"
+    assert ax.size == 5
+    assert ax.edges[0] == -2
+    assert ax.edges[-1] == 3
+    assert (converted.values() == h.values().get()).all()
+    # nanflow is dropped; under/overflow carry over
+    assert (converted.values(flow=True) == h.values(flow=True)[:-1].get()).all()
+
+    h.fill(cp.array([1.0]), weight=cp.array([2.0]))
+    weighted = h.to_hist()
+    variance = weighted.variances()
+    assert variance is not None
+    assert (variance == h.variance().get()).all()


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds `cuda_histogram.axis.Integer(start, stop, *, name="", label="")`, modeled on `boost_histogram.axis.Integer`: unit-width integer bins from `start` (inclusive) to `stop` (exclusive), floats binned by floor, NaN to nanflow.

It is a `Regular` subclass with unit bins, so fill, flow bins, and value slicing (`reduced`/`_ireduce`) reuse the existing dense machinery; `to_boost()`/`to_hist()` convert it to `hist.axis.Integer`, preserving name/label and dropping nanflow like the other dense axes.

Deliberately no flow/growth kwargs to stay out of the way of the dense-axis flow-toggle PR.

Tested on a local CUDA 13 GPU (full suite passes).