### PR TITLE
feat: add underflow/overflow toggles to Regular, Variable, and Integer

### DIFF
--- a/src/cuda_histogram/axis/__init__.py
+++ b/src/cuda_histogram/axis/__init__.py
@@ -369,6 +369,16 @@ class DenseAxis(Axis):
     def reduced(self, islice: slice) -> DenseAxis:
         raise NotImplementedError
 
+    @property
+    def underflow(self) -> bool:
+        """Whether fills below the first bin edge are counted"""
+        return True
+
+    @property
+    def overflow(self) -> bool:
+        """Whether fills at or above the last bin edge are counted"""
+        return True
+
 
 class Bin(DenseAxis):
     """Super class for dense axes.
@@ -388,10 +398,18 @@ class Bin(DenseAxis):
             is used as a keyword in histogram filling, immutable
         label : str
             describes the meaning of the axis, can be changed
+        underflow : bool
+            If False, fills below ``lo`` are discarded instead of counted.
+        overflow : bool
+            If False, fills at or above ``hi`` are discarded instead of
+            counted.  NaN always lands in the nanflow bin, regardless.
 
     This axis will generate frequencies for n+3 bins, special bin indices:
     ``0 = underflow, n+1 = overflow, n+2 = nanflow``
     Bin boundaries are [lo, hi)
+
+    The flow bins are always present in the dense storage layout (and thus in
+    ``values(flow=True)``); a disabled flow bin simply stays empty.
     """
 
     def __init__(
@@ -402,6 +420,8 @@ class Bin(DenseAxis):
         *,
         name: str = "",
         label: str = "",
+        underflow: bool = True,
+        overflow: bool = True,
     ) -> None:
         # _bins is the number of bins when uniform, else the array of edges
         self._bins: Any
@@ -437,6 +457,18 @@ class Bin(DenseAxis):
             )
         self._label = label
         self._name = name
+        self._underflow = underflow
+        self._overflow = overflow
+
+    @property
+    def underflow(self) -> bool:
+        """Whether fills below the first bin edge are counted"""
+        return self._underflow
+
+    @property
+    def overflow(self) -> bool:
+        """Whether fills at or above the last bin edge are counted"""
+        return self._overflow
 
     @property
     def _nanflow_index(self) -> int:
@@ -476,6 +508,9 @@ class Bin(DenseAxis):
     def __setstate__(self, d: dict[str, Any]) -> None:
         if "_interval_bins" in d and "_bin_names" not in d:
             d["_bin_names"] = np.full(d["_interval_bins"][:-1].size, None)
+        # pickles predating the flow toggles
+        d.setdefault("_underflow", True)
+        d.setdefault("_overflow", True)
         self.__dict__ = d
 
     def index(self, identifier: Any) -> Any:
@@ -523,6 +558,11 @@ class Bin(DenseAxis):
             if not super().__eq__(other):
                 return False
             if self._uniform != other._uniform:
+                return False
+            if (self._underflow, self._overflow) != (
+                other._underflow,
+                other._overflow,
+            ):
                 return False
             if self._uniform:
                 return bool(self._bins == other._bins)
@@ -647,8 +687,7 @@ class Bin(DenseAxis):
 
 class Regular(Bin):
     """
-    Make a regular axis with nice keyword arguments for underflow,
-    overflow, and growth.
+    Make a regular axis with uniform binning.
 
     Parameters
     ----------
@@ -662,6 +701,11 @@ class Regular(Bin):
             Axis name.
         label : str
             Axis label.
+        underflow : bool
+            If False, fills below ``start`` are discarded.
+        overflow : bool
+            If False, fills at or above ``stop`` are discarded (NaN still
+            lands in the nanflow bin).
     """
 
     def __init__(
@@ -672,6 +716,8 @@ class Regular(Bin):
         *,
         name: str = "",
         label: str = "",
+        underflow: bool = True,
+        overflow: bool = True,
     ) -> None:
         super().__init__(
             bins,
@@ -679,6 +725,8 @@ class Regular(Bin):
             stop,
             name=name,
             label=label,
+            underflow=underflow,
+            overflow=overflow,
         )
 
     def reduced(self, islice: slice) -> Regular:
@@ -710,7 +758,15 @@ class Regular(Bin):
             hi = self._lo + (islice.stop - 1) * (self._hi - self._lo) / self._bins
             ihi = islice.stop - 1
         bins = ihi - ilo
-        return Regular(bins, lo, hi, name=self._name, label=self._label)
+        return Regular(
+            bins,
+            lo,
+            hi,
+            name=self._name,
+            label=self._label,
+            underflow=self._underflow,
+            overflow=self._overflow,
+        )
 
 
 class Integer(Regular):
@@ -728,6 +784,11 @@ class Integer(Regular):
             Axis name.
         label : str
             Axis label.
+        underflow : bool
+            If False, fills below ``start`` are discarded.
+        overflow : bool
+            If False, fills at or above ``stop`` are discarded (NaN still
+            lands in the nanflow bin).
 
     Float fills bin by floor: any value in ``[v, v + 1)`` lands in the
     bin for integer ``v``.
@@ -740,12 +801,22 @@ class Integer(Regular):
         *,
         name: str = "",
         label: str = "",
+        underflow: bool = True,
+        overflow: bool = True,
     ) -> None:
         start = int(start)
         stop = int(stop)
         if stop <= start:
             raise ValueError(f"stop ({stop}) must be greater than start ({start})")
-        super().__init__(stop - start, start, stop, name=name, label=label)
+        super().__init__(
+            stop - start,
+            start,
+            stop,
+            name=name,
+            label=label,
+            underflow=underflow,
+            overflow=overflow,
+        )
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self._lo}, {self._hi})"
@@ -766,7 +837,12 @@ class Integer(Regular):
         if reduced is self:
             return self
         return Integer(
-            int(reduced._lo), int(reduced._hi), name=self._name, label=self._label
+            int(reduced._lo),
+            int(reduced._hi),
+            name=self._name,
+            label=self._label,
+            underflow=self._underflow,
+            overflow=self._overflow,
         )
 
 
@@ -783,6 +859,11 @@ class Variable(Bin):
             Axis name.
         label : str
             Axis label.
+        underflow : bool
+            If False, fills below the first edge are discarded.
+        overflow : bool
+            If False, fills at or above the last edge are discarded (NaN
+            still lands in the nanflow bin).
     """
 
     def __init__(
@@ -791,8 +872,12 @@ class Variable(Bin):
         *,
         name: str = "",
         label: str = "",
+        underflow: bool = True,
+        overflow: bool = True,
     ) -> None:
-        super().__init__(edges, name=name, label=label)
+        super().__init__(
+            edges, name=name, label=label, underflow=underflow, overflow=overflow
+        )
 
     def reduced(self, islice: slice) -> Variable:
         """
@@ -815,4 +900,10 @@ class Variable(Bin):
         lo = None if islice.start is None else islice.start - 1
         hi = -1 if islice.stop is None else islice.stop
         bins = self._bins[slice(lo, hi)]
-        return Variable(bins, name=self._name, label=self._label)
+        return Variable(
+            bins,
+            name=self._name,
+            label=self._label,
+            underflow=self._underflow,
+            overflow=self._overflow,
+        )

--- a/src/cuda_histogram/hist.py
+++ b/src/cuda_histogram/hist.py
@@ -183,12 +183,23 @@ class Hist:
                 dense_idx.append(islice)
                 new_dims.append(ax.reduced(islice))
 
+        dense_axes = [ax for ax in self._axes if isinstance(ax, DenseAxis)]
+
         def dense_op(array: Any) -> Any:
             """Apply the dense slices, always returning a fresh array"""
             if not dense_idx:
                 return array.copy()
             as_numpy = array.get()
             blocked = np.block(_assemble_blocks(as_numpy, dense_idx))
+            # _assemble_blocks sums out-of-slice content into the flow bins;
+            # a disabled flow bin drops that content instead
+            for i, ax in enumerate(dense_axes):
+                for disabled, flow_bin in (
+                    (not ax.underflow, 0),
+                    (not ax.overflow, -2),
+                ):
+                    if disabled:
+                        blocked[(slice(None),) * i + (flow_bin,)] = 0
             return cupy.asarray(blocked)
 
         out = Hist(*new_dims, label=self._label)
@@ -275,10 +286,27 @@ class Hist:
 
         if self.dense_dim() > 0:
             dense_indices = tuple(
-                cupy.asarray(d.index(value))
+                cupy.atleast_1d(cupy.asarray(d.index(value)))
                 for d, value in zip(self._axes, args, strict=False)
                 if isinstance(d, DenseAxis)
             )
+            # entries landing in a disabled flow bin are discarded
+            dense_axes = [d for d in self._axes if isinstance(d, DenseAxis)]
+            keep = None
+            for i, (d, idx) in enumerate(zip(dense_axes, dense_indices, strict=True)):
+                for disabled, flow_bin in (
+                    (not d.underflow, 0),
+                    (not d.overflow, self._dense_shape[i] - 2),
+                ):
+                    if disabled:
+                        mask = idx != flow_bin
+                        keep = mask if keep is None else keep & mask
+            if keep is not None:
+                dense_indices = cupy.broadcast_arrays(*dense_indices)
+                keep = cupy.broadcast_to(keep, dense_indices[0].shape)
+                dense_indices = tuple(idx[keep] for idx in dense_indices)
+                if weight is not None:
+                    weight = cupy.broadcast_to(weight, keep.shape)[keep]
             xy = cupy.atleast_1d(
                 cupy.ravel_multi_index(dense_indices, self._dense_shape)
             )
@@ -373,9 +401,9 @@ class Hist:
         """
         Convert this cuda_histogram object to a boost_histogram object.
 
-        underflow and overflow are set True and nanflow is lost in the conversion.
-        Categorical axes convert to ``StrCategory`` axes with the same
-        ``growth``/``overflow`` settings.
+        The produced axes carry over each axis's ``underflow``/``overflow``
+        settings; nanflow is lost in the conversion.  Categorical axes convert
+        to ``StrCategory`` axes with the same ``growth``/``overflow`` settings.
 
         Appropriate boost-histogram axis and storage are automatically chosen.
         All the arguments of cuda-histogram's axis and histogram are passed down.
@@ -397,8 +425,8 @@ class Hist:
                     hist.axis.Integer(
                         axis._lo,
                         axis._hi,
-                        underflow=True,
-                        overflow=True,
+                        underflow=axis.underflow,
+                        overflow=axis.overflow,
                         name=axis.name,
                         label=axis.label,
                     )
@@ -409,8 +437,8 @@ class Hist:
                         axis._bins,
                         axis._lo,
                         axis._hi,
-                        underflow=True,
-                        overflow=True,
+                        underflow=axis.underflow,
+                        overflow=axis.overflow,
                         name=axis.name,
                         label=axis.label,
                     )
@@ -419,8 +447,8 @@ class Hist:
                 newaxes.append(
                     hist.axis.Variable(
                         axis.edges().get(),
-                        underflow=True,
-                        overflow=True,
+                        underflow=axis.underflow,
+                        overflow=axis.overflow,
                         name=axis.name,
                         label=axis.label,
                     )
@@ -446,10 +474,13 @@ class Hist:
         out.label = self.label  # type: ignore[attr-defined]
 
         view = out.view(flow=True)
-        # drop the nanflow bin of dense axes; a category axis has no nanflow,
-        # and values(flow=True) already matches its extent
+        # drop the nanflow bin of dense axes, plus any disabled flow bin the
+        # boost view does not have; a category axis has no nanflow, and
+        # values(flow=True) already matches its extent
         nonan = tuple(
-            slice(None) if isinstance(axis, SparseAxis) else slice(None, -1)
+            slice(None if axis.underflow else 1, -1 if axis.overflow else -2)
+            if isinstance(axis, DenseAxis)
+            else slice(None)
             for axis in self.axes()
         )
         if self._sumw2 is None:

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+cp = pytest.importorskip("cupy")
+
+import cuda_histogram
+
+# cupy might be installable on a device with no GPUs
+try:
+    cp.cuda.runtime.getDeviceCount()
+except cp.cuda.runtime.CUDARuntimeError:
+    pytest.skip("CUDA not found", allow_module_level=True)
+
+
+def _flow_hist(*, underflow: bool = True, overflow: bool = True) -> cuda_histogram.Hist:
+    h = cuda_histogram.Hist(
+        cuda_histogram.axis.Regular(
+            4, 0.0, 4.0, name="x", underflow=underflow, overflow=overflow
+        )
+    )
+    h.fill(cp.array([-1.0, 0.5, 1.5, 2.5, 3.5, 5.0, np.nan]))
+    return h
+
+
+def _dense_axis(h: cuda_histogram.Hist, i: int = 0) -> cuda_histogram.axis.Bin:
+    ax = h.axes()[i]
+    assert isinstance(ax, cuda_histogram.axis.Bin)
+    return ax
+
+
+def test_default_flow_unchanged() -> None:
+    h = _flow_hist()
+    ax = _dense_axis(h)
+    assert ax.underflow
+    assert ax.overflow
+    # [underflow, 4 bins, overflow, nanflow]
+    assert h.values(flow=True).get() == pytest.approx([1, 1, 1, 1, 1, 1, 1])
+
+
+def test_underflow_disabled() -> None:
+    h = _flow_hist(underflow=False)
+    assert not _dense_axis(h).underflow
+    assert h.values(flow=True).get() == pytest.approx([0, 1, 1, 1, 1, 1, 1])
+    assert h.values().get() == pytest.approx([1, 1, 1, 1])
+
+
+def test_overflow_disabled_keeps_nanflow() -> None:
+    h = _flow_hist(overflow=False)
+    assert not _dense_axis(h).overflow
+    # 5.0 is discarded, but NaN still lands in nanflow
+    assert h.values(flow=True).get() == pytest.approx([1, 1, 1, 1, 1, 0, 1])
+
+
+def test_weighted_fill_discards_matching_weights() -> None:
+    h = cuda_histogram.Hist(
+        cuda_histogram.axis.Regular(2, 0.0, 2.0, name="x", underflow=False)
+    )
+    h.fill(cp.array([-1.0, 0.5, 1.5]), weight=cp.array([100.0, 2.0, 3.0]))
+    assert h.values(flow=True).get() == pytest.approx([0, 2, 3, 0, 0])
+    assert h.variance(flow=True).get() == pytest.approx([0, 4, 9, 0, 0])
+
+
+def test_variable_flow() -> None:
+    h = cuda_histogram.Hist(
+        cuda_histogram.axis.Variable(
+            [0.0, 1.0, 3.0], name="x", underflow=False, overflow=False
+        )
+    )
+    h.fill(cp.array([-1.0, 0.5, 2.0, 4.0, np.nan]))
+    assert h.values(flow=True).get() == pytest.approx([0, 1, 1, 0, 1])
+
+
+def test_integer_flow() -> None:
+    h = cuda_histogram.Hist(
+        cuda_histogram.axis.Integer(0, 3, name="n", underflow=False, overflow=False)
+    )
+    h.fill(cp.array([-1, 0, 1, 2, 5]))
+    assert h.values(flow=True).get() == pytest.approx([0, 1, 1, 1, 0, 0])
+    converted = h.to_hist()
+    assert converted.axes[0].traits.underflow is False
+    assert converted.axes[0].traits.overflow is False
+    assert converted.values(flow=True) == pytest.approx([1, 1, 1])
+
+
+def test_multiaxis_mask_combines() -> None:
+    h = cuda_histogram.Hist(
+        cuda_histogram.axis.Regular(2, 0.0, 2.0, name="x", underflow=False),
+        cuda_histogram.axis.Regular(2, 0.0, 2.0, name="y", overflow=False),
+    )
+    # (-1, 0.5) dropped by x underflow; (0.5, 5) dropped by y overflow
+    h.fill(cp.array([-1.0, 0.5, 0.5]), cp.array([0.5, 5.0, 1.5]))
+    assert h.values().sum() == 1
+    assert h.values(flow=True).sum() == 1
+
+
+def test_slicing_drops_cropped_content() -> None:
+    h = cuda_histogram.Hist(
+        cuda_histogram.axis.Regular(4, 0.0, 4.0, name="x", overflow=False)
+    )
+    h.fill(cp.array([0.5, 1.5, 2.5, 3.5]))
+    reduced = h[1.0:3.0]
+    assert not _dense_axis(reduced).overflow
+    # 0.5 folds into underflow (enabled); 3.5 would fold into overflow (disabled)
+    assert reduced.values(flow=True).get() == pytest.approx([1, 1, 1, 0, 0])
+
+
+def test_axis_equality_includes_flow() -> None:
+    reg = cuda_histogram.axis.Regular(4, 0.0, 4.0, name="x")
+    assert reg != cuda_histogram.axis.Regular(4, 0.0, 4.0, name="x", underflow=False)
+    assert reg == cuda_histogram.axis.Regular(4, 0.0, 4.0, name="x")
+
+
+def test_to_hist_carries_flow_flags() -> None:
+    pytest.importorskip("hist")
+    h = _flow_hist(underflow=False)
+    converted = h.to_hist()
+    ax = converted.axes[0]
+    assert ax.traits.underflow is False
+    assert ax.traits.overflow is True
+    assert converted.values(flow=True) == pytest.approx([1, 1, 1, 1, 1])
+    assert converted.values() == pytest.approx([1, 1, 1, 1])
+
+    both = _flow_hist(underflow=False, overflow=False).to_hist()
+    assert both.axes[0].traits.underflow is False
+    assert both.axes[0].traits.overflow is False
+    assert both.values(flow=True) == pytest.approx([1, 1, 1, 1])


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds boost-histogram-style `underflow=`/`overflow=` keyword arguments to `Regular`, `Variable`, and `Integer` (default `True`, so existing behavior is unchanged).

The internal `n+3` bin layout is untouched — a disabled flow bin stays allocated but is never counted: `fill()` discards entries that would land there, value slicing drops cropped content instead of re-summing it into the disabled bin, and `to_boost()`/`to_hist()` build the axis with matching flags and skip those bins in the view copy. NaN goes to nanflow regardless of `overflow`, consistent with the package's nanflow deviation. `reduced()`, `__eq__`, and unpickling of old axes all account for the new flags.

Tested on a local CUDA 13 GPU (`uv run --extra cuda13x pytest`).