### PR TITLE
feat: add a Boolean axis

### DIFF
--- a/src/cuda_histogram/axis/__init__.py
+++ b/src/cuda_histogram/axis/__init__.py
@@ -16,6 +16,7 @@ if typing.TYPE_CHECKING:
 
 __all__: list[str] = [
     "Bin",
+    "Boolean",
     "IntCategory",
     "Integer",
     "Interval",
@@ -891,6 +892,70 @@ class Integer(Regular):
             label=self._label,
             underflow=self._underflow,
             overflow=self._overflow,
+        )
+
+
+class Boolean(Regular):
+    """
+    Make an axis with two bins: ``False`` and ``True``.
+
+    Modeled on ``boost_histogram.axis.Boolean``. Fills coerce input to
+    truthiness: nonzero values, including NaN (which is truthy under
+    ``astype(bool)``), count as True. The flow bins of the internal dense
+    layout therefore never fill, and the axis reports
+    ``underflow``/``overflow`` as False so ``to_boost``/``to_hist`` produce
+    a flow-less ``Boolean`` axis.
+
+    Parameters
+    ----------
+        name : str
+            Axis name.
+        label : str
+            Axis label.
+    """
+
+    def __init__(self, *, name: str = "", label: str = "") -> None:
+        super().__init__(
+            2, 0, 2, name=name, label=label, underflow=False, overflow=False
+        )
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}()"
+
+    __hash__ = None  # type: ignore[assignment]
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, Bin) and not isinstance(other, Boolean):
+            return False
+        return super().__eq__(other)
+
+    def index(self, identifier: Any) -> Any:
+        """Index of an identifier, coercing values to truthiness
+
+        Nonzero values map to the True bin (dense index 2), zero to the
+        False bin (dense index 1). NaN is truthy, so it lands in the True
+        bin as in boost-histogram, not in nanflow.
+        """
+        isarray = isinstance(
+            identifier, awkward.Array | cupy.ndarray | np.ndarray | list
+        )
+        if isarray or isinstance(identifier, numbers.Number):
+            values = awkward.to_cupy(identifier)
+            return values.astype(bool).astype(np.int64) + 1
+        return super().index(identifier)
+
+    def _ireduce(self, the_slice: Any) -> slice:
+        if the_slice == slice(None):
+            return slice(None)
+        raise IndexError(
+            f"Cannot slice Boolean axis {self!r}; use to_boost/to_hist for UHI indexing"
+        )
+
+    def reduced(self, islice: slice) -> Boolean:
+        if islice == slice(None):
+            return self
+        raise IndexError(
+            f"Cannot reduce Boolean axis {self!r}; use to_boost/to_hist for UHI indexing"
         )
 
 

--- a/src/cuda_histogram/hist.py
+++ b/src/cuda_histogram/hist.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from cuda_histogram.axis import (
     Axis,
+    Boolean,
     DenseAxis,
     IntCategory,
     Integer,
@@ -408,7 +409,8 @@ class Hist:
         The produced axes carry over each axis's ``underflow``/``overflow``
         settings; nanflow is lost in the conversion.  Categorical axes convert
         to ``StrCategory``/``IntCategory`` axes with the same
-        ``growth``/``overflow`` settings.
+        ``growth``/``overflow`` settings; ``Boolean`` axes convert to flow-less
+        ``Boolean`` axes (their internal flow bins never fill).
 
         Appropriate boost-histogram axis and storage are automatically chosen.
         All the arguments of cuda-histogram's axis and histogram are passed down.
@@ -421,12 +423,15 @@ class Hist:
             hist.axis.Regular
             | hist.axis.Integer
             | hist.axis.Variable
+            | hist.axis.Boolean
             | hist.axis.StrCategory
             | hist.axis.IntCategory
         ] = []
         for axis in self.axes():
-            # Integer subclasses Regular, so it must be checked first
-            if isinstance(axis, Integer):
+            # Boolean and Integer subclass Regular, so check them first
+            if isinstance(axis, Boolean):
+                newaxes.append(hist.axis.Boolean(name=axis.name, label=axis.label))
+            elif isinstance(axis, Integer):
                 newaxes.append(
                     hist.axis.Integer(
                         axis._lo,

--- a/tests/test_hist_tools.py
+++ b/tests/test_hist_tools.py
@@ -680,6 +680,103 @@ def test_mixed_category_axes() -> None:
     assert (out.values() == h.values().get()).all()
 
 
+def test_boolean_axis() -> None:
+    ax = cuda_histogram.axis.Boolean(name="flag", label="Flag")
+    assert ax.size == 2
+    assert ax.name == "flag"
+    assert ax.label == "Flag"
+    assert repr(ax) == "Boolean()"
+    assert (ax.edges() == cp.array([0.0, 1.0, 2.0])).all()
+    assert (ax.centers() == cp.array([0.5, 1.5])).all()
+    # dense indices: 1 = False bin, 2 = True bin; flow bins never fill
+    assert (ax.index(cp.array([False, True])) == cp.array([1, 2])).all()
+    # nonzero coerces to True; NaN is truthy, so it lands in the True bin
+    assert (
+        ax.index(cp.array([0.0, 0.5, -2.0, np.nan])) == cp.array([1, 2, 2, 2])
+    ).all()
+    assert ax == cuda_histogram.axis.Boolean(name="flag")
+    assert ax == "flag"
+    assert ax != cuda_histogram.axis.Regular(2, 0, 2, name="flag")
+    assert cuda_histogram.axis.Regular(2, 0, 2, name="flag") != ax
+
+
+def test_boolean_fill() -> None:
+    h = cuda_histogram.Hist(cuda_histogram.axis.Boolean(name="flag"))
+    assert h.values().shape == (2,)
+    assert h.values(flow=True).shape == (5,)
+
+    h.fill(cp.array([True, False, True, True]))
+    assert (h.values() == cp.array([1.0, 3.0])).all()
+    assert h.variance() is None
+    assert (h.values(flow=True) == cp.array([0, 1, 3, 0, 0])).all()
+
+    # non-bool numerics coerce to truthiness; NaN counts as True, not nanflow
+    h.fill(cp.array([0.0, 2.0, -1.0, np.nan]))
+    assert (h.values() == cp.array([2.0, 6.0])).all()
+    assert h.values(flow=True).sum() == 8
+
+    h.fill(cp.array([0, 7]))  # integer input
+    assert (h.values() == cp.array([3.0, 7.0])).all()
+
+
+def test_boolean_weighted_fill() -> None:
+    h = cuda_histogram.Hist(cuda_histogram.axis.Boolean(name="flag"))
+    h.fill(cp.array([True, False, True]), weight=cp.array([2.0, 3.0, 4.0]))
+    assert (h.values() == cp.array([3.0, 6.0])).all()
+    assert (h.variance() == cp.array([9.0, 20.0])).all()
+
+
+def test_boolean_with_regular() -> None:
+    h = cuda_histogram.Hist(
+        cuda_histogram.axis.Boolean(name="flag"),
+        cuda_histogram.axis.Regular(4, 0, 1, name="x"),
+    )
+    h.fill(cp.array([True, False, True]), cp.array([0.1, 0.3, 0.9]))
+    assert h.values().shape == (2, 4)
+    assert (h.values() == cp.array([[0, 1, 0, 0], [1, 0, 0, 1]])).all()
+
+    # full slices work; the Regular axis can still be sliced by value
+    assert (h[...].values() == h.values()).all()
+    assert h[...].axes() == h.axes()
+    sel = h[:, 0.3]
+    assert (sel.values() == h.values()[:, 1].reshape(2, 1)).all()
+
+    # anything but a full slice on the Boolean axis is an error
+    with pytest.raises(IndexError, match="Boolean"):
+        h[1, :]
+    with pytest.raises(IndexError, match="Boolean"):
+        h[0.5:, :]
+
+
+def test_boolean_to_hist() -> None:
+    import boost_histogram as bh
+    import hist as hist_mod
+
+    h = cuda_histogram.Hist(
+        cuda_histogram.axis.Boolean(name="flag", label="Flag"),
+        cuda_histogram.axis.Regular(4, 0, 1, name="x"),
+    )
+    h.fill(cp.array([True, False, True]), cp.array([0.1, 0.3, 1.5]))
+
+    out = h.to_hist()
+    assert isinstance(out, hist_mod.Hist)
+    assert isinstance(out.axes[0], bh.axis.Boolean)
+    assert out.axes[0].name == "flag"
+    assert out.axes[0].label == "Flag"
+    assert out.axes[0].extent == 2  # no flow bins
+    assert out.storage_type == bh.storage.Double
+    assert (out.values() == h.values().get()).all()
+    # only the Regular axis has flow content to preserve
+    assert out.values(flow=True).sum() == h.values(flow=True).sum()
+    assert out[bh.loc(True), bh.overflow] == 1.0
+
+    h.fill(cp.array([False]), cp.array([0.5]), weight=cp.array([2.0]))
+    out2 = h.to_boost()
+    assert out2.storage_type == bh.storage.Weight
+    assert (out2.values() == h.values().get()).all()
+    assert (out2.variances() == h.variance().get()).all()
+
+
 def test_hist_conversion() -> None:
     import hist as hist_mod
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds `cuda_histogram.axis.Boolean`, modeled on `boost_histogram.axis.Boolean` (two bins: False, True).

- Implemented on top of the existing dense layout as a 2-bin axis; fills coerce input to truthiness (nonzero counts as True), so the under/overflow and nanflow bins never fill. NaN is truthy under `astype(bool)`, so it lands in the True bin, matching boost-histogram, rather than nanflow.
- `to_boost()`/`to_hist()` convert to a flow-less `hist.axis.Boolean`, preserving name/label and dropping the always-empty flow bins.
- Slicing the axis is a clear `IndexError` except for a full slice (use `to_boost`/`to_hist` for UHI indexing).

Tested locally on a CUDA 13 GPU (`uv run --extra cuda13x pytest`).