### PR TITLE
feat: add an IntCategory axis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,9 +53,9 @@ sparse-axis indices) to a dense CuPy array of shape `Hist._dense_shape`.
 `_sumw2` stays `None` until the first weighted `fill()`, at which point
 `_init_sumw2()` seeds it from `_sumw`; `variance()` returns `None` while it is
 `None`, and `to_boost()` picks `Double` vs `Weight` storage from it. The sparse
-key holds one bin index per `StrCategory` axis (empty tuple when there are
-none); index `size` is the overflow bin of a non-growing `overflow=True` axis,
-and unmatched fills on an `overflow=False` axis are discarded entirely.
+key holds one bin index per category axis (empty tuple when there are none);
+index `size` is the overflow bin of a non-growing `overflow=True` axis, and
+unmatched fills on an `overflow=False` axis are discarded entirely.
 `values()`/`variance()` stack the sparse dict into a dense array via
 `Hist._stack_sparse`, reordering so category dimensions land in axis order.
 
@@ -66,13 +66,13 @@ and `size + 1` for `Variable` — these agree because `Variable.size` counts the
 extra `inf` edge appended in `Bin.__init__`. `_overflow_behavior(flow)` is the
 single place that translates `flow=False` into `slice(1, -2)`.
 
-**Filling.** `Hist.fill()` requires CuPy arrays (a plain string per
-`StrCategory` axis). It maps values to indices via `axis.index()`, flattens with
-`cupy.ravel_multi_index`, and accumulates with `cupy.bincount`. Uniform
-(`Regular`) axes compute indices with the `_clip_bins` `cupy.ElementwiseKernel`
-at the top of `axis/__init__.py` (clamps to the flow bins and sends NaN to
-nanflow); `Variable` axes use `cupy.searchsorted` against edges with `inf`
-appended so NaN sorts past it.
+**Filling.** `Hist.fill()` requires CuPy arrays (a plain string/int per
+`StrCategory`/`IntCategory` axis). It maps values to indices via `axis.index()`,
+flattens with `cupy.ravel_multi_index`, and accumulates with `cupy.bincount`.
+Uniform (`Regular`) axes compute indices with the `_clip_bins`
+`cupy.ElementwiseKernel` at the top of `axis/__init__.py` (clamps to the flow
+bins and sends NaN to nanflow); `Variable` axes use `cupy.searchsorted` against
+edges with `inf` appended so NaN sorts past it.
 
 **Indexing.** `Hist.__getitem__` is deliberately narrow: indices are _values in
 bin-edge coordinates_, not integer bin numbers, no interpolation (a
@@ -92,5 +92,6 @@ survive.
 ## Conventions
 
 - `from __future__ import annotations` is a required first import (ruff isort).
-- Axes are `Regular`, `Variable`, and `StrCategory` only; when adding features,
-  check whether boost-histogram already names the concept and match that name.
+- Axes are `Regular`, `Variable`, `StrCategory`, and `IntCategory` only; when
+  adding features, check whether boost-histogram already names the concept and
+  match that name.

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Main features of cuda-histogram:
       - `centers()`
       - `index(...)`
       - ...
-    - `StrCategory` axis (sparse storage, with boost-histogram's `growth` and
-      `overflow` behaviors)
+    - `StrCategory` and `IntCategory` axes (sparse storage, with
+      boost-histogram's `growth` and `overflow` behaviors)
   - Histogram
     - `fill(..., weight=...)` (including `Nan` flow)
     - simple indexing with slicing (see example below)

--- a/src/cuda_histogram/axis/__init__.py
+++ b/src/cuda_histogram/axis/__init__.py
@@ -2,16 +2,21 @@ from __future__ import annotations
 
 import functools
 import numbers
+import typing
 import warnings
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, ClassVar, Generic, TypeVar
 
 import awkward
 import cupy
 import numpy as np
 
+if typing.TYPE_CHECKING:
+    from typing import Self
+
 __all__: list[str] = [
     "Bin",
+    "IntCategory",
     "Integer",
     "Interval",
     "Regular",
@@ -204,39 +209,21 @@ class SparseAxis(Axis):
         raise NotImplementedError
 
 
-def _check_str(category: Any) -> None:
-    if not isinstance(category, str):
-        raise TypeError(
-            f"StrCategory only supports string categories, received {category!r}"
-        )
+_CategoryT = TypeVar("_CategoryT", str, int)
 
 
-class StrCategory(SparseAxis):
-    """A categorical axis with string-valued bins.
+class _Category(SparseAxis, Generic[_CategoryT]):
+    """Shared implementation of ``StrCategory`` and ``IntCategory``.
 
-    Modeled on ``boost_histogram.axis.StrCategory``. Categories are kept in
-    insertion order, and histogram storage is sparse: only filled categories
-    occupy memory.
-
-    Parameters
-    ----------
-        categories : Iterable[str]
-            Initial categories, in bin order.
-        name : str
-            is used as a keyword in histogram filling, immutable
-        label : str
-            describes the meaning of the axis, can be changed
-        growth : bool
-            If True, filling a category not on the axis appends it; a growing
-            axis matches everything, so it has no overflow bin.
-        overflow : bool
-            If True (and not growing), unmatched fills are counted in a
-            trailing overflow bin; if False they are discarded.
+    Categories are kept in insertion order, and histogram storage is sparse:
+    only filled categories occupy memory.
     """
+
+    _category_type: ClassVar[type]
 
     def __init__(
         self,
-        categories: Iterable[str] = (),
+        categories: Iterable[_CategoryT] = (),
         *,
         name: str = "",
         label: str = "",
@@ -244,14 +231,21 @@ class StrCategory(SparseAxis):
         overflow: bool = True,
     ) -> None:
         super().__init__(name, label)
-        self._indices: dict[str, int] = {}
+        self._indices: dict[_CategoryT, int] = {}
         self._growth = growth
         self._overflow = overflow and not growth
         for category in categories:
             self._add(category)
 
-    def _add(self, category: str) -> int:
-        _check_str(category)
+    def _check(self, category: Any) -> None:
+        if not isinstance(category, self._category_type):
+            raise TypeError(
+                f"{type(self).__name__} only supports "
+                f"{self._category_type.__name__} categories, received {category!r}"
+            )
+
+    def _add(self, category: _CategoryT) -> int:
+        self._check(category)
         if category in self._indices:
             raise ValueError(f"Duplicate category {category!r}")
         index = len(self._indices)
@@ -281,20 +275,21 @@ class StrCategory(SparseAxis):
         """Number of categories, including the overflow bin if present"""
         return self.size + 1 if self._overflow else self.size
 
-    def index(self, identifier: str) -> int | None:
+    def index(self, identifier: _CategoryT) -> int | None:
         """Index of a category
 
         Parameters
         ----------
-            identifier : str
-                The category to look up.
+            identifier
+                The category to look up: a ``str`` for ``StrCategory``, an
+                ``int`` for ``IntCategory`` (a mismatch raises ``TypeError``).
 
         Returns the integer bin index of the category. An unknown category
         is appended if the axis was constructed with ``growth=True``;
         otherwise it maps to the overflow bin (index ``size``), or to
         ``None`` (meaning: discard) if ``overflow=False``.
         """
-        _check_str(identifier)
+        self._check(identifier)
         idx = self._indices.get(identifier)
         if idx is not None:
             return idx
@@ -302,11 +297,12 @@ class StrCategory(SparseAxis):
             return self._add(identifier)
         return self.size if self._overflow else None
 
-    def __getitem__(self, index: int) -> str:
+    def __getitem__(self, index: int) -> _CategoryT:
         return self.identifiers()[index]
 
     def _ireduce(self, the_slice: Any) -> list[int]:
-        if isinstance(the_slice, str):
+        out: list[_CategoryT]
+        if isinstance(the_slice, self._category_type):
             if the_slice not in self._indices:
                 raise KeyError(f"No category {the_slice!r} in axis {self!r}")
             out = [the_slice]
@@ -322,16 +318,16 @@ class StrCategory(SparseAxis):
             raise IndexError(f"Cannot understand slice {the_slice!r} on axis {self!r}")
         return [self._indices[k] for k in out]
 
-    def reduced(self, indices: list[int]) -> StrCategory:
+    def reduced(self, indices: list[int]) -> Self:
         """Return a new axis with only the categories at the given indices
 
         Parameters
         ----------
             indices : list[int]
-                Category indices, usually as returned from ``StrCategory._ireduce``
+                Category indices, usually as returned from ``_ireduce``
         """
         categories = self.identifiers()
-        return StrCategory(
+        return type(self)(
             [categories[i] for i in indices],
             name=self._name,
             label=self._label,
@@ -339,9 +335,61 @@ class StrCategory(SparseAxis):
             overflow=self._overflow,
         )
 
-    def identifiers(self) -> list[str]:
-        """List of string categories"""
+    def identifiers(self) -> list[_CategoryT]:
+        """List of categories"""
         return list(self._indices)
+
+
+class StrCategory(_Category[str]):
+    """A categorical axis with string-valued bins.
+
+    Modeled on ``boost_histogram.axis.StrCategory``. Categories are kept in
+    insertion order, and histogram storage is sparse: only filled categories
+    occupy memory.
+
+    Parameters
+    ----------
+        categories : Iterable[str]
+            Initial categories, in bin order.
+        name : str
+            is used as a keyword in histogram filling, immutable
+        label : str
+            describes the meaning of the axis, can be changed
+        growth : bool
+            If True, filling a category not on the axis appends it; a growing
+            axis matches everything, so it has no overflow bin.
+        overflow : bool
+            If True (and not growing), unmatched fills are counted in a
+            trailing overflow bin; if False they are discarded.
+    """
+
+    _category_type: ClassVar[type] = str
+
+
+class IntCategory(_Category[int]):
+    """A categorical axis with integer-valued bins.
+
+    Modeled on ``boost_histogram.axis.IntCategory``. Categories are kept in
+    insertion order, and histogram storage is sparse: only filled categories
+    occupy memory.
+
+    Parameters
+    ----------
+        categories : Iterable[int]
+            Initial categories, in bin order.
+        name : str
+            is used as a keyword in histogram filling, immutable
+        label : str
+            describes the meaning of the axis, can be changed
+        growth : bool
+            If True, filling a category not on the axis appends it; a growing
+            axis matches everything, so it has no overflow bin.
+        overflow : bool
+            If True (and not growing), unmatched fills are counted in a
+            trailing overflow bin; if False they are discarded.
+    """
+
+    _category_type: ClassVar[type] = int
 
 
 class DenseAxis(Axis):

--- a/src/cuda_histogram/hist.py
+++ b/src/cuda_histogram/hist.py
@@ -10,6 +10,7 @@ import numpy as np
 from cuda_histogram.axis import (
     Axis,
     DenseAxis,
+    IntCategory,
     Integer,
     Regular,
     SparseAxis,
@@ -247,20 +248,23 @@ class Hist:
 
         Parameters
         ----------
-            *args : cupy.ndarray or str
+            *args : cupy.ndarray or str or int
                 Provide one CuPy array (0-d is fine) per dense axis and a
-                single string category per ``StrCategory`` axis; plain
-                Python numbers are not accepted.
+                single category per sparse axis: a plain string for
+                ``StrCategory``, a plain int for ``IntCategory``. Plain
+                Python numbers are not accepted for dense axes.
             weight : cupy.ndarray
                 Provide weights.
         """
-        if not all(isinstance(a, cupy.ndarray | str) for a in args):
-            raise TypeError("pass CuPy arrays (or a string per StrCategory axis)")
         if weight is not None and not isinstance(weight, cupy.ndarray):
             raise TypeError("pass CuPy arrays")
 
         if len(self._axes) != len(args):
             raise ValueError("mismatching dimensions for provided values and axes")
+        # sparse axes validate their own scalar category in index()
+        for ax, value in zip(self._axes, args, strict=True):
+            if isinstance(ax, DenseAxis) and not isinstance(value, cupy.ndarray):
+                raise TypeError("pass one CuPy array per dense axis")
 
         indices = tuple(
             d.index(value)
@@ -403,7 +407,8 @@ class Hist:
 
         The produced axes carry over each axis's ``underflow``/``overflow``
         settings; nanflow is lost in the conversion.  Categorical axes convert
-        to ``StrCategory`` axes with the same ``growth``/``overflow`` settings.
+        to ``StrCategory``/``IntCategory`` axes with the same
+        ``growth``/``overflow`` settings.
 
         Appropriate boost-histogram axis and storage are automatically chosen.
         All the arguments of cuda-histogram's axis and histogram are passed down.
@@ -417,6 +422,7 @@ class Hist:
             | hist.axis.Integer
             | hist.axis.Variable
             | hist.axis.StrCategory
+            | hist.axis.IntCategory
         ] = []
         for axis in self.axes():
             # Integer subclasses Regular, so it must be checked first
@@ -456,6 +462,16 @@ class Hist:
             elif isinstance(axis, StrCategory):
                 newaxes.append(
                     hist.axis.StrCategory(
+                        axis.identifiers(),
+                        growth=axis.growth,
+                        overflow=axis.overflow,
+                        name=axis.name,
+                        label=axis.label,
+                    )
+                )
+            elif isinstance(axis, IntCategory):
+                newaxes.append(
+                    hist.axis.IntCategory(
                         axis.identifiers(),
                         growth=axis.growth,
                         overflow=axis.overflow,

--- a/tests/test_hist_tools.py
+++ b/tests/test_hist_tools.py
@@ -477,6 +477,209 @@ def test_str_category_to_boost() -> None:
     assert (hh.values() == h.values().get()).all()
 
 
+def _int_cat_axis(
+    h: cuda_histogram.Hist, i: int = 0
+) -> cuda_histogram.axis.IntCategory:
+    ax = h.axes()[i]
+    assert isinstance(ax, cuda_histogram.axis.IntCategory)
+    return ax
+
+
+def test_int_category_axis() -> None:
+    ax = cuda_histogram.axis.IntCategory([4, 7], name="i", label="ids")
+    assert ax.size == 2
+    assert ax.name == "i"
+    assert ax.label == "ids"
+    assert not ax.growth
+    assert ax.index(4) == 0
+    assert ax.index(7) == 1
+    assert ax[0] == 4
+    assert ax[-1] == 7
+    assert ax.identifiers() == [4, 7]
+    assert repr(ax) == "IntCategory([4, 7])"
+    assert ax.overflow
+    assert ax.index(3) == 2  # overflow bin
+    assert ax.size == 2
+    with pytest.raises(TypeError):
+        ax.index("4")  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        cuda_histogram.axis.IntCategory(["a"])  # type: ignore[list-item]
+    with pytest.raises(ValueError, match="Duplicate"):
+        cuda_histogram.axis.IntCategory([1, 1])
+
+    no_overflow = cuda_histogram.axis.IntCategory([4, 7], overflow=False)
+    assert not no_overflow.overflow
+    assert no_overflow.index(3) is None
+
+    grow = cuda_histogram.axis.IntCategory(growth=True)
+    assert not grow.overflow  # a growing axis matches everything
+    assert grow.size == 0
+    assert grow.index(7) == 0
+    assert grow.index(-2) == 1
+    assert grow.index(7) == 0
+    assert grow.identifiers() == [7, -2]
+
+
+def test_int_category_fill() -> None:
+    h = cuda_histogram.Hist(
+        cuda_histogram.axis.IntCategory(growth=True, name="pdgid"),
+        cuda_histogram.axis.Regular(4, 0, 1, name="x"),
+    )
+    assert h.values().shape == (0, 4)
+    assert h.dense_dim() == 1
+    assert h.sparse_axes() == [h.axes()[0]]
+
+    h.fill(211, cp.array([0.1, 0.3, 0.3]))
+    h.fill(13, cp.array([0.6]))
+    assert h.values().shape == (2, 4)
+    assert (h.values() == cp.array([[1, 2, 0, 0], [0, 0, 1, 0]])).all()
+    assert h.values(flow=True).shape == (2, 7)
+    assert (h.values(flow=True).sum(axis=1) == cp.array([3, 1])).all()
+    assert h.variance() is None
+
+    h.fill(13, cp.array([0.6]), weight=cp.array([2.0]))
+    assert h.variance() is not None
+    assert (h.values() == cp.array([[1, 2, 0, 0], [0, 0, 3, 0]])).all()
+    assert (h.variance() == cp.array([[1, 2, 0, 0], [0, 0, 5, 0]])).all()
+
+    # unknown category on a non-growing axis lands in the overflow bin
+    fixed = cuda_histogram.Hist(
+        cuda_histogram.axis.IntCategory([1, 2], name="pdgid"),
+        cuda_histogram.axis.Regular(4, 0, 1, name="x"),
+    )
+    assert fixed.values().shape == (2, 4)
+    assert fixed.values(flow=True).shape == (3, 7)
+    fixed.fill(2, cp.array([0.1]))
+    fixed.fill(5, cp.array([0.1]))
+    assert (fixed.values() == cp.array([[0, 0, 0, 0], [1, 0, 0, 0]])).all()
+    assert (fixed.values(flow=True)[2] == cp.array([0, 1, 0, 0, 0, 0, 0])).all()
+
+    # with overflow off, unknown categories are discarded
+    discard = cuda_histogram.Hist(
+        cuda_histogram.axis.IntCategory([1, 2], overflow=False, name="pdgid"),
+        cuda_histogram.axis.Regular(4, 0, 1, name="x"),
+    )
+    assert discard.values(flow=True).shape == (2, 7)
+    discard.fill(5, cp.array([0.1]), weight=cp.array([2.0]))
+    assert discard.values(flow=True).sum() == 0
+    assert discard.variance() is None  # the discarded fill never seeded sumw2
+    discard.fill(1, cp.array([0.1]))
+    assert (discard.values() == cp.array([[1, 0, 0, 0], [0, 0, 0, 0]])).all()
+
+
+def test_int_category_getitem() -> None:
+    h = cuda_histogram.Hist(
+        cuda_histogram.axis.IntCategory(growth=True, name="pdgid"),
+        cuda_histogram.axis.Regular(4, 0, 1, name="x"),
+    )
+    h.fill(211, cp.array([0.1, 0.3, 0.3]))
+    h.fill(13, cp.array([0.6]), weight=cp.array([2.0]))
+    h.fill(-11, cp.array([0.9, 0.9]))
+
+    sel = h[13]
+    assert isinstance(sel, cuda_histogram.Hist)
+    assert _int_cat_axis(sel).identifiers() == [13]
+    assert sel.values().shape == (1, 4)
+    assert (sel.values()[0] == h.values()[1]).all()
+    assert (sel.variance()[0] == h.variance()[1]).all()
+
+    # list selection keeps the requested order
+    sub = h[[-11, 211], :]
+    assert _int_cat_axis(sub).identifiers() == [-11, 211]
+    assert (sub.values() == cp.stack([h.values()[2], h.values()[0]])).all()
+
+    assert (h[:, :].values() == h.values()).all()
+    assert (h[211, 0.3].values()[0, 0] == h.values()[0, 1]).all()
+
+    with pytest.raises(KeyError):
+        h[999]
+    with pytest.warns(RuntimeWarning):
+        empty = h[[999], :]
+    assert empty.values().shape == (0, 4)
+
+
+def test_int_category_overflow_slicing_and_convert() -> None:
+    h = cuda_histogram.Hist(
+        cuda_histogram.axis.IntCategory([1, 2], name="i"),
+        cuda_histogram.axis.Regular(4, 0, 1, name="x"),
+    )
+    h.fill(1, cp.array([0.1, 0.3]))
+    h.fill(2, cp.array([0.5]))
+    h.fill(99, cp.array([0.7, 0.7, 0.7]))
+    assert h.values().sum() == 3
+    assert h.values(flow=True).sum() == 6
+
+    # overflow content survives selection, like boost-histogram picks
+    pick = h[2]
+    assert pick.values(flow=True).shape == (2, 7)
+    assert (pick.values(flow=True)[1] == h.values(flow=True)[2]).all()
+    assert pick.values(flow=True)[1].sum() == 3
+
+    out = h.to_boost()
+    assert not out.axes[0].traits.growth
+    assert out.axes[0].traits.overflow
+    assert out.axes[0].extent == 3
+    assert (out.values() == h.values().get()).all()
+    # the overflow bin round-trips (drop only the dense nanflow on our side)
+    assert (out.view(flow=True) == h.values(flow=True)[:, :-1].get()).all()
+
+    no_overflow = cuda_histogram.Hist(
+        cuda_histogram.axis.IntCategory([1, 2], overflow=False, name="i"),
+    )
+    no_overflow.fill(1)
+    out2 = no_overflow.to_boost()
+    assert not out2.axes[0].traits.overflow
+    assert out2.axes[0].extent == 2
+    assert (out2.values() == no_overflow.values().get()).all()
+
+
+def test_int_category_to_boost() -> None:
+    import boost_histogram as bh
+
+    h = cuda_histogram.Hist(
+        cuda_histogram.axis.IntCategory(growth=True, name="pdgid", label="PDG ID"),
+        cuda_histogram.axis.Regular(3, 0, 1, name="x"),
+        label="events",
+    )
+    h.fill(211, cp.array([0.1, 0.5, 1.5]))
+    h.fill(-13, cp.array([-0.5, 0.9]))
+
+    out = h.to_boost()
+    assert isinstance(out.axes[0], bh.axis.IntCategory)
+    assert list(out.axes[0]) == [211, -13]
+    assert out.axes[0].name == "pdgid"
+    assert out.axes[0].label == "PDG ID"
+    assert out.storage_type == bh.storage.Double
+    assert (out.values() == h.values().get()).all()
+    assert out[bh.loc(211), bh.overflow] == 1.0
+    assert out[bh.loc(-13), bh.underflow] == 1.0
+
+    h.fill(-13, cp.array([0.9]), weight=cp.array([2.0]))
+    out = h.to_boost()
+    assert out.storage_type == bh.storage.Weight
+    assert (out.values() == h.values().get()).all()
+    assert (out.variances() == h.variance().get()).all()
+
+    hh = h.to_hist()
+    assert (hh.values() == h.values().get()).all()
+
+
+def test_mixed_category_axes() -> None:
+    h = cuda_histogram.Hist(
+        cuda_histogram.axis.StrCategory(growth=True, name="sample"),
+        cuda_histogram.axis.Regular(3, 0, 1, name="x"),
+        cuda_histogram.axis.IntCategory(growth=True, name="pdgid"),
+    )
+    h.fill("ttbar", cp.array([0.1, 0.5]), 211)
+    h.fill("qcd", cp.array([0.9]), 13)
+    assert h.values().shape == (2, 3, 2)
+    assert (h.values()[0, :, 0] == cp.array([1, 1, 0])).all()
+    assert (h.values()[1, :, 1] == cp.array([0, 0, 1])).all()
+
+    out = h.to_boost()
+    assert (out.values() == h.values().get()).all()
+
+
 def test_hist_conversion() -> None:
     import hist as hist_mod
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds `cuda_histogram.axis.IntCategory`, modeled on `boost_histogram.axis.IntCategory`, with the same `growth`/`overflow` semantics as `StrCategory` (growth appends new categories and disables overflow; `overflow=False` discards unmatched fills).

The shared category logic is factored into a generic `_Category` base, so `StrCategory` and `IntCategory` are thin subclasses that only pin the category type. `Hist.fill()` takes one plain Python `int` per `IntCategory` axis (mirroring the plain-string convention), and `to_boost()`/`to_hist()` convert to `hist.axis.IntCategory` preserving name/label and the overflow bin.

Tests mirror the existing `StrCategory` ones; the full suite was run locally on a CUDA 13 GPU.